### PR TITLE
HCF 750 allow custom script paths

### DIFF
--- a/builder/role_image.go
+++ b/builder/role_image.go
@@ -243,6 +243,7 @@ func (r *RoleImageBuilder) generateRunScript(role *model.Role) ([]byte, error) {
 	}
 
 	runScriptTemplate := template.New("role-runscript")
+	runScriptTemplate.Funcs(template.FuncMap{"is_abs": filepath.IsAbs})
 	context := map[string]interface{}{
 		"role": role,
 	}

--- a/builder/role_image_test.go
+++ b/builder/role_image_test.go
@@ -93,7 +93,7 @@ func TestGenerateRoleImageRunScript(t *testing.T) {
 	roleImageBuilder := NewRoleImageBuilder("foo", compiledPackagesDir, targetPath, "3.14.15", "6.28.30", ui)
 
 	runScriptContents, err := roleImageBuilder.generateRunScript(rolesManifest.Roles[0])
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Contains(string(runScriptContents), "/var/vcap/jobs-src/tor/templates/data/properties.sh.erb")
 	assert.Contains(string(runScriptContents), "/opt/hcf/monitrc.erb")
 	assert.Contains(string(runScriptContents), "/opt/hcf/startup/myrole.sh")
@@ -104,7 +104,7 @@ func TestGenerateRoleImageRunScript(t *testing.T) {
 	assert.Contains(string(runScriptContents), "monit -vI")
 
 	runScriptContents, err = roleImageBuilder.generateRunScript(rolesManifest.Roles[1])
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotContains(string(runScriptContents), "monit -vI")
 	assert.NotContains(string(runScriptContents), "/etc/monitrc")
 	assert.Contains(string(runScriptContents), "/var/vcap/jobs/tor/bin/run")

--- a/builder/role_image_test.go
+++ b/builder/role_image_test.go
@@ -97,6 +97,9 @@ func TestGenerateRoleImageRunScript(t *testing.T) {
 	assert.Contains(string(runScriptContents), "/var/vcap/jobs-src/tor/templates/data/properties.sh.erb")
 	assert.Contains(string(runScriptContents), "/opt/hcf/monitrc.erb")
 	assert.Contains(string(runScriptContents), "/opt/hcf/startup/myrole.sh")
+	assert.Contains(string(runScriptContents), "/script/with/absolute/path.sh")
+	assert.NotContains(string(runScriptContents), "/opt/hcf/startup/script/with/absolute/path.sh")
+	assert.NotContains(string(runScriptContents), "/opt/hcf/startup//script/with/absolute/path.sh")
 	assert.Contains(string(runScriptContents), "/opt/hcf/startup/post_config_script.sh")
 	assert.Contains(string(runScriptContents), "monit -vI")
 

--- a/model/roles.go
+++ b/model/roles.go
@@ -123,6 +123,10 @@ func (r *Role) GetScriptPaths() map[string]string {
 	}
 
 	for _, script := range r.Scripts {
+		if filepath.IsAbs(script) {
+			// Absolute paths _inside_ the container; there is nothing to copy
+			continue
+		}
 		result[script] = filepath.Join(filepath.Dir(r.rolesManifest.manifestFilePath), script)
 	}
 

--- a/model/roles_test.go
+++ b/model/roles_test.go
@@ -28,8 +28,10 @@ func TestLoadRoleManifestOK(t *testing.T) {
 	assert.Equal(2, len(rolesManifest.Roles))
 
 	myrole := rolesManifest.Roles[0]
-	assert.Equal(1, len(myrole.Scripts))
-	assert.Equal("myrole.sh", myrole.Scripts[0])
+	assert.Equal([]string{
+		"myrole.sh",
+		"/script/with/absolute/path.sh",
+	}, myrole.Scripts)
 
 	foorole := rolesManifest.Roles[1]
 	torjob := foorole.Jobs[0]

--- a/scripts/dockerfiles/run.sh
+++ b/scripts/dockerfiles/run.sh
@@ -33,9 +33,9 @@ function run_configgin()
 
 # Run custom role scripts
 {{ with $role := index . "role" }}
-{{ range $i, $script := .Scripts}}
-bash /opt/hcf/startup/{{ $script }}
-{{ end }}
+    {{ range $i, $script := .Scripts}}
+        bash {{ if not (is_abs $script) }}/opt/hcf/startup/{{ end }}{{ $script }}
+    {{ end }}
 {{ end }}
 
 # Process templates
@@ -79,9 +79,9 @@ cron
 
 # Run custom post config role scripts
 {{ with $role := index . "role" }}
-{{ range $i, $script := .PostConfigScripts}}
-bash /opt/hcf/startup/{{ $script }}
-{{ end }}
+    {{ range $i, $script := .PostConfigScripts}}
+        bash {{ if not (is_abs $script) }}/opt/hcf/startup/{{ end }}{{ $script }}
+    {{ end }}
 {{ end }}
 
 # Run

--- a/scripts/dockerfiles/run.sh
+++ b/scripts/dockerfiles/run.sh
@@ -70,6 +70,8 @@ function run_configgin()
 
 # Create run dir
 mkdir -p /var/vcap/sys/run
+chown root:vcap /var/vcap/sys/run
+chmod 775 /var/vcap/sys/run
 
 # Start rsyslog and cron
 service rsyslog start

--- a/scripts/dockerfiles/run.sh
+++ b/scripts/dockerfiles/run.sh
@@ -32,42 +32,40 @@ function run_configgin()
 }
 
 # Run custom role scripts
-{{ with $role := index . "role" }}
-    {{ range $i, $script := .Scripts}}
-        bash {{ if not (is_abs $script) }}/opt/hcf/startup/{{ end }}{{ $script }}
-    {{ end }}
+{{ range $script := .role.Scripts}}
+    bash {{ if not (is_abs $script) }}/opt/hcf/startup/{{ end }}{{ $script }}
 {{ end }}
 
 # Process templates
-{{ with $role := index . "role" }}
-# =====================================================
-{{ range $i, $job := .Jobs}}
-# ============================================================================
-#         Templates for job {{ $job.Name }}
-# ============================================================================
-{{ range $j, $template := $job.Templates }}
-run_configgin "{{$job.Name}}" \
-    "/var/vcap/jobs-src/{{$job.Name}}/templates/{{ $template.SourcePath }}" \
-    "/var/vcap/jobs/{{$job.Name}}/{{$template.DestinationPath}}"
-# =====================================================
-{{ end }}
-{{ if not (eq $role.Type "bosh-task") }}
-# ============================================================================
-#         Monit templates for job {{ $job.Name }}
-# ============================================================================
-run_configgin "{{$job.Name}}" \
-    "/var/vcap/jobs-src/{{$job.Name}}/monit" \
-    "/var/vcap/monit/{{$job.Name}}.monitrc"
-# =====================================================
-{{ end }}
-{{ end }}
-{{ if not (eq .Type "bosh-task") }}
-# Process monitrc.erb template
-run_configgin "{{with $l := index $role.JobNameList 0}}{{$l.Name}}{{end}}" \
-    "/opt/hcf/monitrc.erb" \
-    "/etc/monitrc"
-chmod 0600 /etc/monitrc
-{{ end }}
+{{ with $role := .role }}
+    # =====================================================
+    {{ range $job := $role.Jobs}}
+    # ============================================================================
+    #         Templates for job {{ $job.Name }}
+    # ============================================================================
+        {{ range $template := $job.Templates }}
+            run_configgin "{{$job.Name}}" \
+                "/var/vcap/jobs-src/{{$job.Name}}/templates/{{$template.SourcePath}}" \
+                "/var/vcap/jobs/{{$job.Name}}/{{$template.DestinationPath}}"
+            # =====================================================
+        {{ end }}
+        {{ if not (eq $role.Type "bosh-task") }}
+            # ============================================================================
+            #         Monit templates for job {{ $job.Name }}
+            # ============================================================================
+            run_configgin "{{$job.Name}}" \
+                "/var/vcap/jobs-src/{{$job.Name}}/monit" \
+                "/var/vcap/monit/{{$job.Name}}.monitrc"
+            # =====================================================
+        {{ end }}
+    {{ end }}
+    {{ if not (eq $role.Type "bosh-task") }}
+        # Process monitrc.erb template
+        run_configgin "{{(index $role.JobNameList 0).Name}}" \
+            "/opt/hcf/monitrc.erb" \
+            "/etc/monitrc"
+        chmod 0600 /etc/monitrc
+    {{ end }}
 {{ end }}
 
 # Create run dir
@@ -78,32 +76,28 @@ service rsyslog start
 cron
 
 # Run custom post config role scripts
-{{ with $role := index . "role" }}
-    {{ range $i, $script := .PostConfigScripts}}
-        bash {{ if not (is_abs $script) }}/opt/hcf/startup/{{ end }}{{ $script }}
-    {{ end }}
+{{ range $script := .role.PostConfigScripts}}
+    bash {{ if not (is_abs $script) }}/opt/hcf/startup/{{ end }}{{ $script }}
 {{ end }}
 
 # Run
-{{ with $role := index . "role" }}
-{{ if eq .Type "bosh-task" }}
-{{ range $i, $job := .Jobs}}
-/var/vcap/jobs/{{ $job.Name }}/bin/run
-{{ end }}
+{{ if eq .role.Type "bosh-task" }}
+    {{ range $job := .role.Jobs}}
+        /var/vcap/jobs/{{ $job.Name }}/bin/run
+    {{ end }}
 {{ else }}
 
-monit -vI &
-pid=$!
-echo "pid = $pid"
+    monit -vI &
+    pid=$!
+    echo "pid = $pid"
 
-killer() {
-  echo "killing $pid"
-  kill $pid
-}
+    killer() {
+      echo "killing $pid"
+      kill $pid
+    }
 
-trap killer INT TERM
+    trap killer INT TERM
 
-( while $(sleep 1); do true; done )
+    ( while $(sleep 1); do true; done )
 
-{{ end }}
 {{ end }}

--- a/test-assets/role-manifests/tor-good.yml
+++ b/test-assets/role-manifests/tor-good.yml
@@ -1,7 +1,7 @@
 ---
 roles:
 - name: myrole
-  scripts: ["myrole.sh"]
+  scripts: ["myrole.sh", "/script/with/absolute/path.sh"]
   post_config_scripts: ["post_config_script.sh"] 
   jobs:
   - name: new_hostname


### PR DESCRIPTION
We can now have absolute paths in `scripts:` and `post_config_scripts:` in the role manifest.  They will *not* be copied into the image (instead they're assumed to already exist), and will be run via `bash`.

Also cleaned up `run.sh` to make it more readable.