### PR TITLE
HCF-926 Force mount a tmpfs volume on /tmp when compiling

### DIFF
--- a/docker/docker.go
+++ b/docker/docker.go
@@ -252,9 +252,14 @@ func (d *ImageManager) RunInContainer(containerName string, imageName string, cm
 			Privileged:     false,
 			Binds:          []string{},
 			ReadonlyRootfs: false,
+			Tmpfs:          make(map[string]string),
 		},
 		Name: containerName,
 	}
+
+	// Add a tmpfs mount at /tmp to fix issues with compilation of `tar`
+	// (aufs appears to give a different inode between dirent and stat)
+	cco.HostConfig.Tmpfs["/tmp"] = "size=100M,exec"
 
 	if inPath != "" {
 		cco.HostConfig.Binds = append(cco.HostConfig.Binds, fmt.Sprintf("%s:%s:ro", inPath, ContainerInPath))

--- a/docker/docker_test.go
+++ b/docker/docker_test.go
@@ -215,6 +215,36 @@ func TestRunInContainerWithOutFiles(t *testing.T) {
 	assert.NoError(err)
 }
 
+func TestRunInContainerTmpMount(t *testing.T) {
+	assert := assert.New(t)
+
+	dockerManager, err := NewImageManager()
+
+	buf := new(bytes.Buffer)
+	stdoutWriter := NewFormattingWriter(buf, nil)
+
+	exitCode, container, err := dockerManager.RunInContainer(
+		getTestName(),
+		dockerImageName,
+		[]string{"cat", "/proc/self/mounts"},
+		"",
+		"",
+		false,
+		stdoutWriter,
+		nil,
+	)
+
+	if !assert.NoError(err) {
+		return
+	}
+	assert.Equal(0, exitCode)
+	assert.Contains(buf.String(), "tmpfs /tmp tmpfs rw", "Failed to find tmpfs mount on /tmp")
+
+	err = dockerManager.RemoveContainer(container.ID)
+	assert.NoError(err)
+
+}
+
 func TestRunInContainerWithWritableOutFiles(t *testing.T) {
 	assert := assert.New(t)
 


### PR DESCRIPTION
When building the `tar` package, sometimes the build fails because (as far as we can tell) aufs has a bug where `dirent_t.d_ino` differs from `stat_t.st_ino`.  This causes a configure check to fail (some of the time) which ends up causing compilation failures due to not having [`tar.git#e9ddc08d`](http://git.savannah.gnu.org/cgit/tar.git/commit/?id=e9ddc08da0982f36581ae5a8c7763453ff41cfe8)

Having a tmpfs mount at `/tmp` should resolve the issue, as that would mean there is no aufs involved, and therefore no magic around `dirent` vs `stat`.