### PR TITLE
HCF-908 Fix path in monit logrotate config

### DIFF
--- a/scripts/dockerfiles/Dockerfile-base
+++ b/scripts/dockerfiles/Dockerfile-base
@@ -33,5 +33,8 @@ ADD configgin /opt/hcf/configgin/
 # Add rsyslog configuration
 ADD rsyslog_conf.tgz /
 
+# Fix monit's logrotate config (created in the `apt-get install monit` above) to our new log file location
+RUN sed -i 's/log/vcap\/monit/' /etc/logrotate.d/monit
+
 # Make logrotate run hourly, not daily
 RUN mv /etc/cron.daily/logrotate /etc/cron.hourly/logrotate

--- a/scripts/dockerfiles/Dockerfile-base
+++ b/scripts/dockerfiles/Dockerfile-base
@@ -36,5 +36,8 @@ ADD rsyslog_conf.tgz /
 # Fix monit's logrotate config (created in the `apt-get install monit` above) to our new log file location
 RUN sed -i 's/log/vcap\/monit/' /etc/logrotate.d/monit
 
+# Allow monit to reload during logrotate
+RUN echo "#!/bin/sh\nexit 0" > /usr/sbin/policy-rc.d
+
 # Make logrotate run hourly, not daily
 RUN mv /etc/cron.daily/logrotate /etc/cron.hourly/logrotate

--- a/scripts/dockerfiles/Dockerfile-base
+++ b/scripts/dockerfiles/Dockerfile-base
@@ -36,7 +36,10 @@ ADD rsyslog_conf.tgz /
 # Fix monit's logrotate config (created in the `apt-get install monit` above) to our new log file location
 RUN sed -i 's/log/vcap\/monit/' /etc/logrotate.d/monit
 
-# Allow monit to reload during logrotate
+# Monit needs to reload after rotating logs, however, the default policy-rc.d in Ubuntu's docker image forbids it
+# This default is in place due to errors when services try to restart during `docker build`
+# See https://github.com/docker/docker/blob/243d4dcc7e9ea3eb665301d5e3756afa4adb04f7/contrib/mkimage/debootstrap#L43-L45
+# It should not pose a problem at this point to re-allow service restarts
 RUN echo "#!/bin/sh\nexit 0" > /usr/sbin/policy-rc.d
 
 # Make logrotate run hourly, not daily


### PR DESCRIPTION
There is already a monit logrotate config created during its installation.
It looks like this:
```
/var/log/monit.log {
        rotate 4
        weekly
        minsize 1M
        missingok
        create 640 root adm
        notifempty
        compress
        delaycompress
        postrotate
                invoke-rc.d monit reload > /dev/null
        endscript
}
```
All that's needed is fixing the log path from the default to the one we set in `monitrc.erb`
