### PR TITLE
HCF-958 Use dumb-init as init rather than monit

### DIFF
--- a/scripts/dockerfiles/Dockerfile-base
+++ b/scripts/dockerfiles/Dockerfile-base
@@ -22,6 +22,9 @@ RUN useradd -m --comment 'hcf user' vcap && \
     DEBIAN_FRONTEND=noninteractive locale-gen en_US.UTF-8 && \
     dpkg-reconfigure -fnoninteractive -pcritical tzdata && \
     dpkg-reconfigure locales && \
+    wget https://github.com/Yelp/dumb-init/releases/download/v1.1.3/dumb-init_1.1.3_amd64.deb && \
+    dpkg -i dumb-init_*.deb && \
+    rm -f dumb-init_*.deb && \
     (useradd --system --user-group --no-create-home syslog || true) && \
     usermod -G vcap syslog
 

--- a/scripts/dockerfiles/run.sh
+++ b/scripts/dockerfiles/run.sh
@@ -123,5 +123,5 @@ done
     {{ end }}
 {{ else }}
     # Replace bash with monit to handle both SIGTERM and SIGINT
-    exec monit -vI
+    exec dumb-init -- monit -vI
 {{ end }}


### PR DESCRIPTION
Monit is actually a terrible init (which it really wasn't designed to be — it only does monitoring, not signal handling).  That caused things to be horribly broken.  Use dumb-init (which only does the signal handling)
instead.  Since SIGINT/SIGTERM are still forwarded to monit, that doesn't break anything.