### PR TITLE
[HCF-900] Added command 'show descriptions'.

### DIFF
--- a/app/fissile_test.go
+++ b/app/fissile_test.go
@@ -90,6 +90,36 @@ func TestListProperties(t *testing.T) {
 	}
 }
 
+func TestListDescriptions(t *testing.T) {
+	ui := termui.New(os.Stdin, ioutil.Discard, nil)
+	assert := assert.New(t)
+
+	workDir, err := os.Getwd()
+	assert.Nil(err)
+
+	badReleasePath := filepath.Join(workDir, "../test-assets/bad-release")
+	badReleasePathCacheDir := filepath.Join(badReleasePath, "bosh-cache")
+	releasePath := filepath.Join(workDir, "../test-assets/ntp-release")
+	releasePathCacheDir := filepath.Join(releasePath, "bosh-cache")
+
+	f := NewFissileApplication(".", ui)
+
+	err = f.LoadReleases([]string{badReleasePath}, []string{""}, []string{""}, badReleasePathCacheDir)
+	assert.Error(err, "Expected ListDescriptions to not find the release")
+
+	err = f.LoadReleases([]string{releasePath}, []string{""}, []string{""}, releasePathCacheDir)
+	if assert.NoError(err) {
+		err = f.ListPropertyDescriptions("human")
+		assert.NoError(err, "Expected ListDescriptions to list release properties for human consumption")
+
+		err = f.ListPropertyDescriptions("json")
+		assert.NoError(err, "Expected ListDescriptions to list release properties in JSON")
+
+		err = f.ListPropertyDescriptions("yaml")
+		assert.NoError(err, "Expected ListDescriptions to list release properties in YAML")
+	}
+}
+
 func TestDevDiffConfigurations(t *testing.T) {
 	assert := assert.New(t)
 	workDir, err := os.Getwd()

--- a/cmd/show-descriptions.go
+++ b/cmd/show-descriptions.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// showDescriptionsCmd represents the descriptions command
+var showDescriptionsCmd = &cobra.Command{
+	Use:   "descriptions",
+	Short: "Displays descriptions of BOSH properties, per jobs.",
+	Long: `
+Displays a report of all properties of all the jobs in the referenced releases.
+The report lists the properties per job per release, with their descriptions.
+`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// Show property information
+
+		if err := fissile.LoadReleases(
+			flagRelease,
+			flagReleaseName,
+			flagReleaseVersion,
+			flagCacheDir,
+		); err != nil {
+			return err
+		}
+
+		return fissile.ListPropertyDescriptions(flagOutputFormat)
+	},
+}
+
+func init() {
+	showCmd.AddCommand(showDescriptionsCmd)
+}


### PR DESCRIPTION
Analogous to 'show properties', it returns descriptions instead of defaults.
