### PR TITLE
HCF-583 Reduce copying when building packages layer image

### DIFF
--- a/app/fissile.go
+++ b/app/fissile.go
@@ -367,11 +367,7 @@ func (f *Fissile) GeneratePackagesRoleImage(repository string, roleManifest *mod
 	}
 	f.UI.Println(color.GreenString("Done."))
 
-	for err = range errors {
-		return err
-	}
-
-	return nil
+	return <-errors
 }
 
 // GenerateRoleImages generates all role images using dev releases

--- a/app/fissile_test.go
+++ b/app/fissile_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -14,7 +15,7 @@ import (
 )
 
 func TestListPackages(t *testing.T) {
-	ui := termui.New(os.Stdin, ioutil.Discard, nil)
+	ui := termui.New(&bytes.Buffer{}, ioutil.Discard, nil)
 	assert := assert.New(t)
 
 	workDir, err := os.Getwd()
@@ -37,7 +38,7 @@ func TestListPackages(t *testing.T) {
 }
 
 func TestListJobs(t *testing.T) {
-	ui := termui.New(os.Stdin, ioutil.Discard, nil)
+	ui := termui.New(&bytes.Buffer{}, ioutil.Discard, nil)
 	assert := assert.New(t)
 
 	workDir, err := os.Getwd()
@@ -61,7 +62,7 @@ func TestListJobs(t *testing.T) {
 }
 
 func TestListProperties(t *testing.T) {
-	ui := termui.New(os.Stdin, ioutil.Discard, nil)
+	ui := termui.New(&bytes.Buffer{}, ioutil.Discard, nil)
 	assert := assert.New(t)
 
 	workDir, err := os.Getwd()

--- a/builder/packages_image_test.go
+++ b/builder/packages_image_test.go
@@ -31,7 +31,7 @@ func TestGenerateDockerfile(t *testing.T) {
 	assert := assert.New(t)
 
 	ui := termui.New(
-		os.Stdin,
+		&bytes.Buffer{},
 		ioutil.Discard,
 		nil,
 	)
@@ -64,7 +64,7 @@ func TestCreatePackagesDockerStream(t *testing.T) {
 	assert := assert.New(t)
 
 	ui := termui.New(
-		os.Stdin,
+		&bytes.Buffer{},
 		ioutil.Discard,
 		nil,
 	)

--- a/builder/packages_image_test.go
+++ b/builder/packages_image_test.go
@@ -1,18 +1,62 @@
 package builder
 
 import (
+	"archive/tar"
+	"bytes"
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/hpcloud/fissile/model"
-	"github.com/hpcloud/fissile/util"
 	"github.com/hpcloud/termui"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCreatePackagesDockerBuildDir(t *testing.T) {
+func TestGenerateDockerfile(t *testing.T) {
+	assert := assert.New(t)
+
+	ui := termui.New(
+		os.Stdin,
+		ioutil.Discard,
+		nil,
+	)
+
+	workDir, err := os.Getwd()
+	assert.NoError(err)
+
+	compiledPackagesDir := filepath.Join(workDir, "../test-assets/tor-boshrelease-fake-compiled")
+	targetPath, err := ioutil.TempDir("", "fissile-test")
+	assert.NoError(err)
+	defer os.RemoveAll(targetPath)
+
+	packagesImageBuilder, err := NewPackagesImageBuilder("foo", compiledPackagesDir, targetPath, "3.14.15", ui)
+	assert.NoError(err)
+
+	baseImage := "scratch:latest"
+
+	dockerfile := bytes.Buffer{}
+	err = packagesImageBuilder.generateDockerfile(baseImage, &dockerfile)
+	assert.NoError(err)
+
+	var lines []string
+	for _, line := range strings.Split(dockerfile.String(), "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			lines = append(lines, line)
+		}
+	}
+
+	assert.Equal([]string{
+		"FROM scratch:latest",
+		"ADD specs /opt/hcf/specs",
+		"ADD packages-src /var/vcap/packages-src/",
+	}, lines, "Unexpected dockerfile contents found")
+}
+
+func TestCreatePackagesDockerStream(t *testing.T) {
 	assert := assert.New(t)
 
 	ui := termui.New(
@@ -39,40 +83,82 @@ func TestCreatePackagesDockerBuildDir(t *testing.T) {
 	rolesManifest, err := model.LoadRoleManifest(roleManifestPath, []*model.Release{release})
 	assert.NoError(err)
 
-	roleImageBuilder, err := NewPackagesImageBuilder("foo", compiledPackagesDir, targetPath, "3.14.15", ui)
+	packagesImageBuilder, err := NewPackagesImageBuilder("foo", compiledPackagesDir, targetPath, "3.14.15", ui)
 	assert.NoError(err)
 
-	dockerfileDir, err := roleImageBuilder.CreatePackagesDockerBuildDir(
+	tarStream, errors, err := packagesImageBuilder.CreatePackagesDockerStream(
 		rolesManifest,
 		filepath.Join(workDir, "../test-assets/test-opinions/opinions.yml"),
 		filepath.Join(workDir, "../test-assets/test-opinions/dark-opinions.yml"),
 	)
 	assert.NoError(err)
-	defer os.RemoveAll(dockerfileDir)
-
-	assert.Equal(targetPath, filepath.Dir(dockerfileDir), "Docker file %s not created in directory %s", dockerfileDir, targetPath)
+	defer tarStream.Close()
 
 	pkg := getPackage(rolesManifest.Roles, "myrole", "tor", "tor")
 	if !assert.NotNil(pkg) {
 		return
 	}
 
-	for _, info := range []struct {
-		path  string
-		isDir bool
-		desc  string
-	}{
-		{path: ".", isDir: true, desc: "role dir"},
-		{path: "Dockerfile", desc: "Dockerfile"},
-		{path: "root", isDir: true, desc: "image root"},
-		{path: filepath.Join("root/var/vcap/packages-src", pkg.Fingerprint), isDir: true, desc: "package dir"},
-		{path: filepath.Join("root/var/vcap/packages-src", pkg.Fingerprint, "bar"), desc: "compilation artifact"},
-		{path: "root/opt/hcf/specs/myrole/tor.json", desc: "job spec"},
-	} {
-		path := filepath.ToSlash(filepath.Join(dockerfileDir, info.path))
-		assert.NoError(util.ValidatePath(path, info.isDir, info.desc))
+	expectedContents := map[string]string{
+		"Dockerfile": `
+			FROM foo-role-base:3.14.15
+			ADD specs /opt/hcf/specs
+			ADD packages-src /var/vcap/packages-src/`,
+		"specs/foorole/tor.json": `{
+				"job": {
+					"name": "foorole",
+					"templates": [{"name": "tor"}]
+				},
+				"networks": {
+					"default": {}
+				},
+				"parameters": {},
+				"properties": {
+					"tor": {
+						"client_keys": null,
+						"hashed_control_password": null,
+						"hostname": "localhost",
+						"private_key": null
+					}
+				}
+			}`,
+		// The next file is empty
+		"packages-src/b9973278a447dfb5e8e67661deaa5fe7001ad742/foo": ``,
+	}
+	tarReader := tar.NewReader(tarStream)
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		}
+		if !assert.NoError(err) {
+			break
+		}
+		if expected, ok := expectedContents[header.Name]; ok {
+			actual, err := ioutil.ReadAll(tarReader)
+			assert.NoError(err)
+			if strings.HasSuffix(header.Name, ".json") {
+				assert.JSONEq(expected, string(actual))
+			} else {
+				var expectedLines, actualLines []string
+				for _, line := range strings.Split(expected, "\n") {
+					line = strings.TrimSpace(line)
+					if line != "" {
+						expectedLines = append(expectedLines, line)
+					}
+				}
+				for _, line := range strings.Split(string(actual), "\n") {
+					line = strings.TrimSpace(line)
+					if line != "" {
+						actualLines = append(actualLines, line)
+					}
+				}
+				assert.Equal(expectedLines, actualLines)
+			}
+		}
 	}
 
-	// jobs-src should not be there
-	assert.Error(util.ValidatePath(filepath.ToSlash(filepath.Join(dockerfileDir, "root/var/vcap/jobs-src")), true, "job directory"))
+	for err := range errors {
+		assert.NoError(err)
+	}
 }

--- a/builder/role_image_test.go
+++ b/builder/role_image_test.go
@@ -21,7 +21,7 @@ func TestGenerateRoleImageDockerfile(t *testing.T) {
 	assert := assert.New(t)
 
 	ui := termui.New(
-		os.Stdin,
+		&bytes.Buffer{},
 		ioutil.Discard,
 		nil,
 	)
@@ -73,7 +73,7 @@ func TestGenerateRoleImageRunScript(t *testing.T) {
 	assert := assert.New(t)
 
 	ui := termui.New(
-		os.Stdin,
+		&bytes.Buffer{},
 		ioutil.Discard,
 		nil,
 	)
@@ -127,7 +127,7 @@ func TestGenerateRoleImageDockerfileDir(t *testing.T) {
 	assert := assert.New(t)
 
 	ui := termui.New(
-		os.Stdin,
+		&bytes.Buffer{},
 		ioutil.Discard,
 		nil,
 	)
@@ -252,7 +252,7 @@ func TestBuildRoleImages(t *testing.T) {
 	assert := assert.New(t)
 
 	ui := termui.New(
-		os.Stdin,
+		&bytes.Buffer{},
 		ioutil.Discard,
 		nil,
 	)

--- a/compilator/compilator_test.go
+++ b/compilator/compilator_test.go
@@ -1,6 +1,7 @@
 package compilator
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -29,7 +30,7 @@ const (
 var dockerImageName string
 
 var ui = termui.New(
-	os.Stdin,
+	&bytes.Buffer{},
 	ioutil.Discard,
 	nil,
 )

--- a/docker/docker_test.go
+++ b/docker/docker_test.go
@@ -1,8 +1,11 @@
 package docker
 
 import (
+	"archive/tar"
 	"bytes"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -434,4 +437,51 @@ func TestFormatWriterOneLine(t *testing.T) {
 	verifyWriteOutput(t, "aaa\nbbb\nccc")
 	verifyWriteOutput(t, "multipl", "e\ncalls")
 	verifyWriteOutput(t, "multipl", "e\ncalls\n")
+}
+
+func TestBuildImageFromStream(t *testing.T) {
+	assert := assert.New(t)
+
+	dockerManager, err := NewImageManager()
+	assert.NoError(err)
+
+	imageName := uuid.New()
+	hasImage, err := dockerManager.HasImage(imageName)
+	if assert.NoError(err) {
+		assert.False(hasImage, "Failed to get an unused image name")
+	}
+
+	pipeReader, pipeWriter := io.Pipe()
+
+	doneCh := make(chan struct{})
+	go func() {
+		tarStream := tar.NewWriter(pipeWriter)
+		contents := bytes.NewBufferString("FROM scratch\nENV hello=world")
+		header := tar.Header{
+			Name:     "Dockerfile",
+			Mode:     0644,
+			Size:     int64(contents.Len()),
+			Typeflag: tar.TypeReg,
+		}
+		assert.NoError(tarStream.WriteHeader(&header))
+		_, err := io.Copy(tarStream, contents)
+		assert.NoError(err)
+		assert.NoError(tarStream.Close(), "Error closing tar stream")
+		assert.NoError(pipeWriter.Close(), "Error closing tar pipe")
+		close(doneCh)
+	}()
+
+	err = dockerManager.BuildImageFromStream(pipeReader, imageName, ioutil.Discard)
+	if assert.NoError(err) {
+		hasImage, err = dockerManager.HasImage(imageName)
+		if assert.NoError(err) {
+			assert.True(hasImage, "Image did not build")
+		}
+		err = dockerManager.RemoveImage(imageName)
+		assert.NoError(err, "Failed to remove image %s", imageName)
+		hasImage, err = dockerManager.HasImage(imageName)
+		if assert.NoError(err) {
+			assert.False(hasImage, "Failed to remove image")
+		}
+	}
 }

--- a/scripts/dockerfiles/Dockerfile-packages
+++ b/scripts/dockerfiles/Dockerfile-packages
@@ -1,3 +1,5 @@
 FROM {{ index . "base_image" }}
 
-ADD root /
+ADD specs /opt/hcf/specs
+
+ADD packages-src /var/vcap/packages-src/


### PR DESCRIPTION
Instead of copying all the compiled files to a scratch workspace and telling docker to build from there, just build the tar file ourselves (which is what would have happened before too).  This reduces a set of read/write that didn't need to happen.

In tests, it reduced rebuilding the packages layer image from ~4:30 to ~3:40.

