### PR TITLE
HCF-1056 disable monit logging to disk

### DIFF
--- a/scripts/dockerfiles/monitrc.erb
+++ b/scripts/dockerfiles/monitrc.erb
@@ -1,5 +1,4 @@
 set daemon 10
-set logfile /var/vcap/monit/monit.log
 
 # We use a random account here that's not read-only to allow local access to
 # monit via the monit CLI. This is the only mechanism we've found that ensures


### PR DESCRIPTION
It's already being logged to stdout (which gets handled by our docker logging infrastructure), there's no need to keep a copy on disk in a container.