### PR TITLE
HCF-1057 Make sure that default properties are isolated to each release

### DIFF
--- a/config-store/config_store.go
+++ b/config-store/config_store.go
@@ -127,7 +127,7 @@ func getAllPropertiesForRoleManifest(roleManifest *model.RoleManifest) (map[*mod
 // If any key exists in props with no default value, it is skipped as children are expected.
 // Only the top level key being missing can generate errors; if any child is missing, they are emitted as
 // warnings on warningWriter.
-func checkKeysInProperties(opinions map[string]interface{}, props map[*model.Release]map[string]interface{}, namesWithoutDefaults map[*model.Release]map[string]struct{}, opinionName string, warningWriter io.Writer) error {
+func checkKeysInProperties(opinions map[string]interface{}, props map[*model.Release]map[string]interface{}, namesWithoutDefaultsPerRelease map[*model.Release]map[string]struct{}, opinionName string, warningWriter io.Writer) error {
 	var results []string
 	var warnings []string
 
@@ -175,10 +175,10 @@ func checkKeysInProperties(opinions map[string]interface{}, props map[*model.Rel
 		}
 	}
 
-	flattenedNamesWithoutDefaults := make(map[string]struct{})
-	for _, releaseNamesWithoutDefaults := range namesWithoutDefaults {
+	flattenedNamesWithoutDefaultsPerRelease := make(map[string]struct{})
+	for _, releaseNamesWithoutDefaults := range namesWithoutDefaultsPerRelease {
 		for name := range releaseNamesWithoutDefaults {
-			flattenedNamesWithoutDefaults[name] = struct{}{}
+			flattenedNamesWithoutDefaultsPerRelease[name] = struct{}{}
 		}
 	}
 
@@ -187,7 +187,7 @@ func checkKeysInProperties(opinions map[string]interface{}, props map[*model.Rel
 		return fmt.Errorf("failed to load %s opinions from %+v", opinionName, opinions)
 	}
 
-	checkInner(properties, flattenedProps, flattenedNamesWithoutDefaults, []string{})
+	checkInner(properties, flattenedProps, flattenedNamesWithoutDefaultsPerRelease, []string{})
 
 	if len(results) > 0 {
 		indent := "\n    "

--- a/config-store/config_writer_json_provider.go
+++ b/config-store/config_writer_json_provider.go
@@ -21,10 +21,10 @@ const (
 
 type jsonConfigWriterProvider struct {
 	opinions *opinions
-	allProps map[string]interface{}
+	allProps map[*model.Release]map[string]interface{}
 }
 
-func newJSONConfigWriterProvider(opinions *opinions, allProps map[string]interface{}) (*jsonConfigWriterProvider, error) {
+func newJSONConfigWriterProvider(opinions *opinions, allProps map[*model.Release]map[string]interface{}) (*jsonConfigWriterProvider, error) {
 	return &jsonConfigWriterProvider{
 		opinions: opinions,
 		allProps: allProps,
@@ -60,7 +60,7 @@ func (w *jsonConfigWriterProvider) WriteConfigs(roleManifest *model.RoleManifest
 				return err
 			}
 
-			properties, err := getPropertiesForJob(job, w.allProps, w.opinions)
+			properties, err := getPropertiesForJob(job, w.allProps[job.Release], w.opinions)
 			if err != nil {
 				return err
 			}

--- a/test-assets/ntp-release/jobs/ntpd/spec
+++ b/test-assets/ntp-release/jobs/ntpd/spec
@@ -13,3 +13,7 @@ properties:
   with.json.default:
     description: A property to test JSON serialization
     default: { key: value }
+  tor.private_key:
+    # This is not actually relevant for this release; it's here to test
+    # fissile's behaviour when multiple releases define a property.
+    default: M3Efvw4x3kzW+YBWR1oPG7hoUcPcFYXWxoYkYR5+KT4=

--- a/util/json_helper.go
+++ b/util/json_helper.go
@@ -64,3 +64,48 @@ func jsonMarshalHelper(input interface{}) (interface{}, *jsonMarshalError) {
 		return input, nil
 	}
 }
+
+// JSONMergeBlobs merges two JSON-compatible maps.  It is an error if the two
+// maps have children that have the same path to the values.
+func JSONMergeBlobs(dest, src map[string]interface{}) error {
+	return jsonMergeBlobsHelper(dest, src, []string{})
+}
+
+func jsonMergeBlobsHelper(dest, src map[string]interface{}, path []string) error {
+	for k, v := range src {
+		old, ok := dest[k]
+		if !ok {
+			// No old value
+			dest[k] = v
+			continue
+		}
+		oldMap, ok := old.(map[string]interface{})
+		if !ok {
+			// old value is _not_ a map; not sure about new value yet
+			if !reflect.DeepEqual(old, v) {
+				if old == nil {
+					// Allow overriding nils
+					dest[k] = v
+					continue
+				}
+				if v == nil {
+					// Ignore new nils
+					continue
+				}
+				return fmt.Errorf("Invalid merge near %s: cannot merge %v with %v",
+					strings.Join(append(path, k), "."), old, v)
+			}
+			dest[k] = v
+			continue
+		}
+		newMap, ok := v.(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("Invalid merge near %s: was %v, new value is %v",
+				strings.Join(append(path, k), "."), old, v)
+		}
+		if err := jsonMergeBlobsHelper(oldMap, newMap, append(path, k)); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/util/json_helper_test.go
+++ b/util/json_helper_test.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -64,6 +65,88 @@ func TestJSONHelperValidInput(t *testing.T) {
 			if assert.NoError(err, "Unexpected error for test sample %s", testData.name) {
 				assert.JSONEq(testData.json, string(result), "Unexpected result for test sample %s", testData.name)
 			}
+		}
+	}
+}
+
+type jsonMergeBlobsTestData struct {
+	name     string
+	source   string
+	dest     string
+	expected string
+	errMsg   string
+}
+
+func TestMergeJSONBlobs(t *testing.T) {
+	assert := assert.New(t)
+
+	testDataList := []jsonMergeBlobsTestData{
+		jsonMergeBlobsTestData{
+			name:     "Simple copy",
+			source:   `{"a": 1}`,
+			dest:     `{}`,
+			expected: `{"a": 1}`,
+		},
+		jsonMergeBlobsTestData{
+			name:     "Simple merge",
+			source:   `{"a": 1}`,
+			dest:     `{"b": 2}`,
+			expected: `{"a": 1, "b": 2}`,
+		},
+		jsonMergeBlobsTestData{
+			name:     "No input",
+			source:   `{}`,
+			dest:     `{"b": 2}`,
+			expected: `{"b": 2}`,
+		},
+		jsonMergeBlobsTestData{
+			name:     "Merging hashes",
+			source:   `{"root": {"a": 1}}`,
+			dest:     `{"root": {"b": 2}}`,
+			expected: `{"root": {"a": 1, "b": 2}}`,
+		},
+		jsonMergeBlobsTestData{
+			name:     "Ignore equal values",
+			source:   `{"root": {"child": 1}}`,
+			dest:     `{"root": {"child": 1}}`,
+			expected: `{"root": {"child": 1}}`,
+		},
+		jsonMergeBlobsTestData{
+			name:   "Error on unequal values",
+			source: `{"root": {"child": 1}}`,
+			dest:   `{"root": {"child": 2}}`,
+			errMsg: "near root.child: cannot merge 2 with 1",
+		},
+		jsonMergeBlobsTestData{
+			name:     "Ignore equal arrays",
+			source:   `{"root": {"child": [1, 2]}}`,
+			dest:     `{"root": {"child": [1, 2]}}`,
+			expected: `{"root": {"child": [1, 2]}}`,
+		},
+		jsonMergeBlobsTestData{
+			name:   "Error on merging arrays",
+			source: `{"root": {"child": [1]}}`,
+			dest:   `{"root": {"child": [2]}}`,
+			errMsg: "near root.child: cannot merge [2] with [1]",
+		},
+	}
+
+	for _, testData := range testDataList {
+		var source, dest map[string]interface{}
+		assert.NoError(json.Unmarshal([]byte(testData.source), &source),
+			"Error unmarshaling source data for test sample %s", testData.name)
+		assert.NoError(json.Unmarshal([]byte(testData.dest), &dest),
+			"Error unmarshaling destination data for test sample %s", testData.name)
+		err := JSONMergeBlobs(dest, source)
+		if testData.errMsg != "" {
+			assert.Error(err, "Expected test sample %s to result in an error", testData.name)
+			assert.Contains(err.Error(), testData.errMsg,
+				"Error message did not contain expected string for thest sample %s", testData.name)
+		} else if assert.NoError(err, "Unexpected error for test sample %s", testData.name) {
+			result, err := json.Marshal(dest)
+			assert.NoError(err, "Unexpected error marshalling result")
+			assert.JSONEq(testData.expected, string(result),
+				"Unexpected result for test sample %s", testData.name)
 		}
 	}
 }


### PR DESCRIPTION
That is, default properties from one release should not have any effect on jobs from a different release, even when they are in the same role.
