### PR TITLE
[HCF-1074] Refactor the root PersistentPreRunE

### DIFF
--- a/cmd/build-layer.go
+++ b/cmd/build-layer.go
@@ -15,7 +15,10 @@ var buildLayerCmd = &cobra.Command{
 	Use:   "layer",
 	Short: "Has subcommands for building Docker layers used during the creation of your images.",
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		if err := RootCmd.PersistentPreRunE(cmd, args); err != nil {
+		// Inline the parts of the RootCmd.PersistentPreRunE we need.
+		// Exclude the validateReleaseArgs(), this part we don't want.
+
+		if err := validateBasicFlags(); err != nil {
 			return err
 		}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -52,37 +52,7 @@ agent.
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 
-		flagRoleManifest = viper.GetString("role-manifest")
-		flagRelease = splitNonEmpty(viper.GetString("release"), ",")
-		flagReleaseName = splitNonEmpty(viper.GetString("release-name"), ",")
-		flagReleaseVersion = splitNonEmpty(viper.GetString("release-version"), ",")
-		flagCacheDir = viper.GetString("cache-dir")
-		flagWorkDir = viper.GetString("work-dir")
-		flagRepository = viper.GetString("repository")
-		flagWorkers = viper.GetInt("workers")
-		flagConfiggin = viper.GetString("configgin")
-		flagLightOpinions = viper.GetString("light-opinions")
-		flagDarkOpinions = viper.GetString("dark-opinions")
-		flagOutputFormat = viper.GetString("output")
-
-		extendPathsFromWorkDirectory()
-
-		if err = absolutePaths(
-			&flagRoleManifest,
-			&flagCacheDir,
-			&flagWorkDir,
-			&flagConfiggin,
-			&flagLightOpinions,
-			&flagDarkOpinions,
-			&workPathCompilationDir,
-			&workPathConfigDir,
-			&workPathBaseDockerfile,
-			&workPathDockerDir,
-		); err != nil {
-			return err
-		}
-
-		if flagRelease, err = absolutePathsForArray(flagRelease); err != nil {
+		if err = validateBasicFlags(); err != nil {
 			return err
 		}
 
@@ -247,6 +217,46 @@ func extendPathsFromWorkDirectory() {
 	if flagDarkOpinions == "" {
 		flagDarkOpinions = filepath.Join(workDir, "dark-opinions.yml")
 	}
+}
+
+func validateBasicFlags() error {
+	var err error
+
+	flagRoleManifest = viper.GetString("role-manifest")
+	flagRelease = splitNonEmpty(viper.GetString("release"), ",")
+	flagReleaseName = splitNonEmpty(viper.GetString("release-name"), ",")
+	flagReleaseVersion = splitNonEmpty(viper.GetString("release-version"), ",")
+	flagCacheDir = viper.GetString("cache-dir")
+	flagWorkDir = viper.GetString("work-dir")
+	flagRepository = viper.GetString("repository")
+	flagWorkers = viper.GetInt("workers")
+	flagConfiggin = viper.GetString("configgin")
+	flagLightOpinions = viper.GetString("light-opinions")
+	flagDarkOpinions = viper.GetString("dark-opinions")
+	flagOutputFormat = viper.GetString("output")
+
+	extendPathsFromWorkDirectory()
+
+	if err = absolutePaths(
+		&flagRoleManifest,
+		&flagCacheDir,
+		&flagWorkDir,
+		&flagConfiggin,
+		&flagLightOpinions,
+		&flagDarkOpinions,
+		&workPathCompilationDir,
+		&workPathConfigDir,
+		&workPathBaseDockerfile,
+		&workPathDockerDir,
+	); err != nil {
+		return err
+	}
+
+	if flagRelease, err = absolutePathsForArray(flagRelease); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func validateReleaseArgs() error {


### PR DESCRIPTION
Let the `build layer` use only the basic validation, excluding the bogus/superfluous release validation.