### PR TITLE
[HCF-1080] New sub command "build cleancache". 

### DIFF
--- a/app/fissile.go
+++ b/app/fissile.go
@@ -321,7 +321,6 @@ func (f *Fissile) CleanCache(targetPath string) error {
 		for _, pkg := range release.Packages {
 			referenced[pkg.Version] = 1
 		}
-
 	}
 
 	/// 2. Scan local compilation cache, compare to referenced,
@@ -349,7 +348,7 @@ func (f *Fissile) CleanCache(targetPath string) error {
 	}
 
 	if removed == 0 {
-		f.UI.Printf("Nothing found to remove\n")
+		f.UI.Println("Nothing found to remove")
 		return nil
 	}
 

--- a/app/fissile_test.go
+++ b/app/fissile_test.go
@@ -14,6 +14,24 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestCleanCacheEmpty(t *testing.T) {
+	ui := termui.New(&bytes.Buffer{}, ioutil.Discard, nil)
+	assert := assert.New(t)
+
+	workDir, err := os.Getwd()
+	assert.Nil(err)
+
+	releasePath := filepath.Join(workDir, "../test-assets/ntp-release")
+	releasePathCacheDir := filepath.Join(releasePath, "bosh-cache")
+
+	f := NewFissileApplication(".", ui)
+	err = f.LoadReleases([]string{releasePath}, []string{""}, []string{""}, releasePathCacheDir)
+	if assert.NoError(err) {
+		err = f.CleanCache(workDir + "compilation")
+		assert.Nil(err, "Expected CleanCache to find the release")
+	}
+}
+
 func TestListPackages(t *testing.T) {
 	ui := termui.New(&bytes.Buffer{}, ioutil.Discard, nil)
 	assert := assert.New(t)

--- a/cmd/build-cleancache.go
+++ b/cmd/build-cleancache.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// buildCleancacheCmd represents the cleancache command
+var buildCleancacheCmd = &cobra.Command{
+	Use:   "cleancache",
+	Short: "Removes unused BOSH packages from the compilation cache.",
+	Long: `
+This command will inspect the compilation cache populated by its sibling "packages"
+and remove all which are not required anymore.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if err := fissile.LoadReleases(
+			flagRelease,
+			flagReleaseName,
+			flagReleaseVersion,
+			flagCacheDir,
+		); err != nil {
+			return err
+		}
+
+		return fissile.CleanCache(workPathCompilationDir)
+	},
+}
+
+func init() {
+	buildCmd.AddCommand(buildCleancacheCmd)
+}

--- a/cmd/build-cleancache.go
+++ b/cmd/build-cleancache.go
@@ -13,12 +13,13 @@ This command will inspect the compilation cache populated by its sibling "packag
 and remove all which are not required anymore.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 
-		if err := fissile.LoadReleases(
+		err := fissile.LoadReleases(
 			flagRelease,
 			flagReleaseName,
 			flagReleaseVersion,
 			flagCacheDir,
-		); err != nil {
+		)
+		if err != nil {
 			return err
 		}
 

--- a/cmd/build-cleancache.go
+++ b/cmd/build-cleancache.go
@@ -4,8 +4,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// buildCleancacheCmd represents the cleancache command
-var buildCleancacheCmd = &cobra.Command{
+// buildCleanCacheCmd represents the cleancache command
+var buildCleanCacheCmd = &cobra.Command{
 	Use:   "cleancache",
 	Short: "Removes unused BOSH packages from the compilation cache.",
 	Long: `
@@ -27,5 +27,5 @@ and remove all which are not required anymore.`,
 }
 
 func init() {
-	buildCmd.AddCommand(buildCleancacheCmd)
+	buildCmd.AddCommand(buildCleanCacheCmd)
 }

--- a/cmd/build-images.go
+++ b/cmd/build-images.go
@@ -37,12 +37,13 @@ the image.
 		flagBuildImagesNoBuild = viper.GetBool("no-build")
 		flagBuildImagesForce = viper.GetBool("force")
 
-		if err := fissile.LoadReleases(
+		err := fissile.LoadReleases(
 			flagRelease,
 			flagReleaseName,
 			flagReleaseVersion,
 			flagCacheDir,
-		); err != nil {
+		)
+		if err != nil {
 			return err
 		}
 

--- a/cmd/build-packages.go
+++ b/cmd/build-packages.go
@@ -25,12 +25,13 @@ compiled once.
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 
-		if err := fissile.LoadReleases(
+		err := fissile.LoadReleases(
 			flagRelease,
 			flagReleaseName,
 			flagReleaseVersion,
 			flagCacheDir,
-		); err != nil {
+		)
+		if err != nil {
 			return err
 		}
 

--- a/cmd/show-image.go
+++ b/cmd/show-image.go
@@ -25,12 +25,13 @@ This command is useful in conjunction with docker (e.g. ` + "`docker rmi $(fissi
 		flagShowImageDockerOnly = viper.GetBool("docker-only")
 		flagShowImageWithSizes = viper.GetBool("with-sizes")
 
-		if err := fissile.LoadReleases(
+		err := fissile.LoadReleases(
 			flagRelease,
 			flagReleaseName,
 			flagReleaseVersion,
 			flagCacheDir,
-		); err != nil {
+		)
+		if err != nil {
 			return err
 		}
 

--- a/cmd/show-properties.go
+++ b/cmd/show-properties.go
@@ -15,12 +15,13 @@ The report lists the properties per job per release, with their default value.
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Show property information
 
-		if err := fissile.LoadReleases(
+		err := fissile.LoadReleases(
 			flagRelease,
 			flagReleaseName,
 			flagReleaseVersion,
 			flagCacheDir,
-		); err != nil {
+		)
+		if err != nil {
 			return err
 		}
 

--- a/cmd/show-release.go
+++ b/cmd/show-release.go
@@ -15,12 +15,13 @@ The report contains the name, version, description and counts of jobs and packag
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Show job information
 
-		if err := fissile.LoadReleases(
+		err := fissile.LoadReleases(
 			flagRelease,
 			flagReleaseName,
 			flagReleaseVersion,
 			flagCacheDir,
-		); err != nil {
+		)
+		if err != nil {
 			return err
 		}
 


### PR DESCRIPTION
Removes package data not referenced (anymore) by the loaded release(s) from the local compilation cache.