### PR TITLE
HCF-1112 embed configgin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "scripts/configgin"]
+	path = scripts/configgin
+	url = https://github.com/hpcloud/configgin

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ lint:
 vet:
 	${GIT_ROOT}/make/vet
 
-bindata:
+bindata: scripts/configgin/output/configgin.tgz
 	${GIT_ROOT}/make/bindata
 
 build:
@@ -42,3 +42,8 @@ reap:
 
 markdown:
 	${GIT_ROOT}/make/generate-markdown
+
+configgin: scripts/configgin/output/configgin.tgz
+
+scripts/configgin/output/configgin.tgz:
+	${GIT_ROOT}/make/configgin

--- a/app/fissile.go
+++ b/app/fissile.go
@@ -95,7 +95,7 @@ func (f *Fissile) CreateBaseCompilationImage(baseImageName, repository string, k
 }
 
 // GenerateBaseDockerImage generates a base docker image to be used as a FROM for role images
-func (f *Fissile) GenerateBaseDockerImage(targetPath, configginTarball, baseImage string, noBuild bool, repository string) error {
+func (f *Fissile) GenerateBaseDockerImage(targetPath, baseImage string, noBuild bool, repository string) error {
 	dockerManager, err := docker.NewImageManager()
 	if err != nil {
 		return fmt.Errorf("Error connecting to docker: %s", err.Error())
@@ -135,7 +135,7 @@ func (f *Fissile) GenerateBaseDockerImage(targetPath, configginTarball, baseImag
 		docker.ColoredBuildStringFunc(baseImageName),
 	)
 
-	tarPopulator := baseImageBuilder.NewDockerPopulator(configginTarball)
+	tarPopulator := baseImageBuilder.NewDockerPopulator()
 	err = dockerManager.BuildImageFromCallback(baseImageName, stdoutWriter, tarPopulator)
 	if err != nil {
 		log.WriteTo(f.UI)

--- a/builder/base_image.go
+++ b/builder/base_image.go
@@ -5,11 +5,11 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"path/filepath"
 	"strings"
 	"text/template"
 
+	"github.com/hpcloud/fissile/scripts/configgin"
 	"github.com/hpcloud/fissile/scripts/dockerfiles"
 	"github.com/hpcloud/fissile/util"
 )
@@ -27,7 +27,7 @@ func NewBaseImageBuilder(baseImage string) *BaseImageBuilder {
 }
 
 // NewDockerPopulator returns a function that will populate the docker tar archive
-func (b *BaseImageBuilder) NewDockerPopulator(configginTarballPath string) func(*tar.Writer) error {
+func (b *BaseImageBuilder) NewDockerPopulator() func(*tar.Writer) error {
 	return func(tarWriter *tar.Writer) error {
 		// Generate dockerfile
 		dockerfileContents, err := b.generateDockerfile()
@@ -62,12 +62,12 @@ func (b *BaseImageBuilder) NewDockerPopulator(configginTarballPath string) func(
 		}
 
 		// Add configgin
-		configginGzip, err := ioutil.ReadFile(configginTarballPath)
+		configginGzip, err := configgin.Asset("configgin.tgz")
 		if err != nil {
 			return err
 		}
 		err = util.TargzIterate(
-			configginTarballPath,
+			"configgin.tgz",
 			bytes.NewReader(configginGzip),
 			func(reader *tar.Reader, header *tar.Header) error {
 				header.Name = filepath.Join("configgin", header.Name)

--- a/cmd/build-layer-stemcell.go
+++ b/cmd/build-layer-stemcell.go
@@ -20,7 +20,6 @@ Fissile will create a Dockerfile and a directory structure with all dependencies
 
 		return fissile.GenerateBaseDockerImage(
 			workPathBaseDockerfile,
-			flagConfiggin,
 			flagBuildLayerFrom,
 			flagBuildLayerNoBuild,
 			flagRepository,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,7 +25,6 @@ var (
 	flagWorkDir        string
 	flagRepository     string
 	flagWorkers        int
-	flagConfiggin      string
 	flagLightOpinions  string
 	flagDarkOpinions   string
 	flagOutputFormat   string
@@ -138,13 +137,6 @@ func init() {
 	)
 
 	RootCmd.PersistentFlags().StringP(
-		"configgin",
-		"f",
-		"",
-		"Path to the tarball containing configgin.",
-	)
-
-	RootCmd.PersistentFlags().StringP(
 		"light-opinions",
 		"l",
 		"",
@@ -206,10 +198,6 @@ func extendPathsFromWorkDirectory() {
 		flagRoleManifest = filepath.Join(workDir, "role-manifest.yml")
 	}
 
-	if flagConfiggin == "" {
-		flagConfiggin = filepath.Join(workDir, "configgin.tar.gz")
-	}
-
 	if flagLightOpinions == "" {
 		flagLightOpinions = filepath.Join(workDir, "opinions.yml")
 	}
@@ -230,7 +218,6 @@ func validateBasicFlags() error {
 	flagWorkDir = viper.GetString("work-dir")
 	flagRepository = viper.GetString("repository")
 	flagWorkers = viper.GetInt("workers")
-	flagConfiggin = viper.GetString("configgin")
 	flagLightOpinions = viper.GetString("light-opinions")
 	flagDarkOpinions = viper.GetString("dark-opinions")
 	flagOutputFormat = viper.GetString("output")
@@ -241,7 +228,6 @@ func validateBasicFlags() error {
 		&flagRoleManifest,
 		&flagCacheDir,
 		&flagWorkDir,
-		&flagConfiggin,
 		&flagLightOpinions,
 		&flagDarkOpinions,
 		&workPathCompilationDir,

--- a/make/bindata
+++ b/make/bindata
@@ -28,3 +28,13 @@ go-bindata -pkg=compilation -o=./scripts/compilation/compilation.go \
     -prefix ./test-assets \
     ./scripts/compilation \
     ./test-assets/scripts/compilation/*.sh
+
+if ! test -f ./scripts/configgin/output/configgin.tgz ; then
+    make/configgin
+fi
+
+# We don't use bindata's compression as it seems to do worse than the default
+# gzip compression from tar
+go-bindata -nocompress -pkg=configgin -o=./scripts/configgin/configgin.go \
+    -prefix=./scripts/configgin/output \
+    ./scripts/configgin/output/configgin.tgz

--- a/make/configgin
+++ b/make/configgin
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# This script will package configgin
+
+set -o errexit -o nounset
+
+cd scripts/configgin
+# Make sure to delete previous bindata output so it doesn't go into the archive
+rm -rf output/ configgin.go
+make/package
+mv output/configgin-*.tgz output/configgin.tgz


### PR DESCRIPTION
This embeds configgin into the fissile binary so we never end up using the wrong version.  It does so by submoduling configgin (using the public URL) and go-bindata.

This _does_ bloat the size of the binary from 15M to 23M for me, though.