### PR TITLE
HCF-1122 Update configgin to build on OS X

### DIFF
--- a/make/clean
+++ b/make/clean
@@ -9,5 +9,5 @@ rm -f ${GIT_ROOT}/fissile
 rm -f ${GIT_ROOT}/scripts/compilation/compilation.go
 rm -f ${GIT_ROOT}/scripts/dockerfiles/dockerfiles.go
 rm -f ${GIT_ROOT}/scripts/templates/transformations.go
-rm -r ${GIT_ROOT}/scripts/configgin/configgin.go
+rm -f ${GIT_ROOT}/scripts/configgin/configgin.go
 rm -rf ${GIT_ROOT}/scripts/configgin/output

--- a/make/clean
+++ b/make/clean
@@ -9,3 +9,5 @@ rm -f ${GIT_ROOT}/fissile
 rm -f ${GIT_ROOT}/scripts/compilation/compilation.go
 rm -f ${GIT_ROOT}/scripts/dockerfiles/dockerfiles.go
 rm -f ${GIT_ROOT}/scripts/templates/transformations.go
+rm -r ${GIT_ROOT}/scripts/configgin/configgin.go
+rm -rf ${GIT_ROOT}/scripts/configgin/output

--- a/make/configgin
+++ b/make/configgin
@@ -7,5 +7,5 @@ set -o errexit -o nounset
 cd scripts/configgin
 # Make sure to delete previous bindata output so it doesn't go into the archive
 rm -rf output/ configgin.go
-make/package
+make dist
 mv output/configgin-*.tgz output/configgin.tgz


### PR DESCRIPTION
Also add configgin build results to `make clean` target and calls
`make dist` instead of invoking `make/package` to build configgin.