### PR TITLE
HCF-1144 Enable OSX build and dist

### DIFF
--- a/make/build
+++ b/make/build
@@ -15,7 +15,7 @@ ${GIT_ROOT}/make/bindata
 OSES="linux darwin"
 GOARCH=${GOARCH:-$(go env GOARCH)}
 
-for OS in ${OSES}; do \
+for OS in ${OSES}; do
   GOOS="${OS}" go build -ldflags="-X main.version=${APP_VERSION}" -o "build/${OS}-${GOARCH}/fissile" 
 done 
 

--- a/make/build
+++ b/make/build
@@ -8,9 +8,14 @@ set +o errexit
 
 . ${GIT_ROOT}/make/include/versioning
 
-set -o errexit
-
-set -o nounset
+set -o errexit -o nounset
 
 ${GIT_ROOT}/make/bindata
-go build -ldflags="-X main.version=${APP_VERSION}"
+
+OSES="linux darwin"
+GOARCH=${GOARCH:-$(go env GOARCH)}
+
+for OS in ${OSES}; do \
+  GOOS="${OS}" go build -ldflags="-X main.version=${APP_VERSION}" -o "build/${OS}-${GOARCH}/fissile" 
+done 
+

--- a/make/package
+++ b/make/package
@@ -6,8 +6,9 @@ GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
 
 set -o errexit -o nounset
 
-GOOS=${GOOS:-$(go env GOOS)}
+OSES="linux darwin"
 GOARCH=${GOARCH:-$(go env GOARCH)}
 
-${GIT_ROOT}/make/build
-tar czf ${APP_VERSION}.${GOOS}-${GOARCH}.tgz fissile
+for OS in ${OSES}; do \
+  tar czf ${APP_VERSION}.${OS}-${GOARCH}.tgz build/${OS}-${GOARCH}/fissile
+done

--- a/make/package
+++ b/make/package
@@ -9,6 +9,6 @@ set -o errexit -o nounset
 OSES="linux darwin"
 GOARCH=${GOARCH:-$(go env GOARCH)}
 
-for OS in ${OSES}; do \
+for OS in ${OSES}; do
   tar czf ${APP_VERSION}.${OS}-${GOARCH}.tgz build/${OS}-${GOARCH}/fissile
 done


### PR DESCRIPTION
CI part of this PR: https://github.com/hpcloud/fissile-ci/pull/13

Some notes:
* `build` no longer builds the fissile binary straight into the working repo, but into a `build/<os-and-arch>` folder, as with the cf plugins Makefiles. It sets the golang `$GOOS` env var before building.
* `dist` still creates a `.tgz` with the same name format, just creates a second .tgz now.
* `clean` didn't need to be changed, as it already deleted any folder named `build` (Leftovers from a previous folder structure?)
* I didn't test the new darwin fissile binary on OSX.

