### PR TITLE
[HCF-1155][HCF-776] Implement support for post-start scripts.

### DIFF
--- a/builder/base_image.go
+++ b/builder/base_image.go
@@ -41,11 +41,12 @@ func (b *BaseImageBuilder) NewDockerPopulator() func(*tar.Writer) error {
 			return err
 		}
 
-		// Add rsyslog_conf and monitrc.erb
+		// Add rsyslog_conf, monitrc.erb, and the post-start handler.
 		for _, assetName := range dockerfiles.AssetNames() {
 			switch {
 			case strings.HasPrefix(assetName, "rsyslog_conf/"):
 			case assetName == "monitrc.erb":
+			case assetName == "post-start.sh":
 			default:
 				continue
 			}

--- a/scripts/dockerfiles/Dockerfile-base
+++ b/scripts/dockerfiles/Dockerfile-base
@@ -34,6 +34,9 @@ RUN useradd -m --comment 'hcf user' vcap && \
 
 ADD monitrc.erb /opt/hcf/monitrc.erb
 
+ADD post-start.sh /opt/hcf/post-start.sh
+RUN chmod ug+x /opt/hcf/post-start.sh
+
 # Install configgin
 ADD configgin /opt/hcf/configgin/
 

--- a/scripts/dockerfiles/monitrc.erb
+++ b/scripts/dockerfiles/monitrc.erb
@@ -14,3 +14,13 @@ include /etc/monit/monitrc.d/rsyslog
 
 include /var/vcap/monit/*.monitrc
 include /var/vcap/monit/job/*.monitrc
+
+# Standard fissile job to handle post-start scripts.  Currently the
+# start command does its own dependency checking to work around issues
+# in monit. When we reach use of monit 5.15+ the dependency
+# information can shift out of the script to this job. It makes the
+# job dynamic however, i.e. it will then have to be created and added
+# by run.sh (As a zomega.monitrc file in the standard place).
+
+check file zomega path /var/vcap/monit/ready
+  start program = "/opt/hcf/post-start.sh"

--- a/scripts/dockerfiles/monitrc.erb
+++ b/scripts/dockerfiles/monitrc.erb
@@ -20,7 +20,7 @@ include /var/vcap/monit/job/*.monitrc
 # in monit. When we reach use of monit 5.15+ the dependency
 # information can shift out of the script to this job. It makes the
 # job dynamic however, i.e. it will then have to be created and added
-# by run.sh (As a zomega.monitrc file in the standard place).
+# by run.sh (As a post-start.monitrc file in the standard place).
 
-check file zomega path /var/vcap/monit/ready
+check file post-start path /var/vcap/monit/ready
   start program = "/opt/hcf/post-start.sh"

--- a/scripts/dockerfiles/post-start.sh
+++ b/scripts/dockerfiles/post-start.sh
@@ -11,7 +11,7 @@
 #
 # * `monit summary` is used to check if the __other__ jobs are up.
 #   Nothing is done while they are not up yet. We know that we are
-#   `zomega`, important to exclude ourselves from the check
+#   `post-start`, important to exclude ourselves from the check
 #
 # Doing our own dependency checking works around issues in monit.
 # This can be shifted to monit itself ('depends on') when we reach use
@@ -20,7 +20,7 @@
 (
   flock -n 9 || exit 1
 
-  notyet=$(monit summary | tail -n+3 | grep -v zomega | grep -v 'Accessible\|Running')
+  notyet=$(monit summary | tail -n+3 | grep -v post-start | grep -v 'Accessible\|Running')
   if [ -z "$notyet" ]
   then
       scripts="$(find /var/vcap/jobs/*/bin -name post-start)"

--- a/scripts/dockerfiles/post-start.sh
+++ b/scripts/dockerfiles/post-start.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+#set -e
+# Cannot use this generally. Interferes with the check via `monit summary`.
+# I.e. when things are ready the failure of grep to match aborts us.
+
+# Check for post-start scripts to run. We may not have any.
+#
+# * `flock` is used to guard against monit starting this script
+#   multiple times when our dependency checking and/or the invoked
+#   scripts are taking too long.
+#
+# * `monit summary` is used to check if the __other__ jobs are up.
+#   Nothing is done while they are not up yet. We know that we are
+#   `zomega`, important to exclude ourselves from the check
+#
+# Doing our own dependency checking works around issues in monit.
+# This can be shifted to monit itself ('depends on') when we reach use
+# of monit v5.15+ where the issues are fixed.
+
+(
+  flock -n 9 || exit 1
+
+  notyet=$(monit summary | tail -n+3 | grep -v zomega | grep -v 'Accessible\|Running')
+  if [ -z "$notyet" ]
+  then
+      scripts="$(find /var/vcap/jobs/*/bin -name post-start)"
+      set -e
+      for fname in ${scripts}
+      do
+	  echo bash $fname
+	  bash $fname
+      done
+      touch /var/vcap/monit/ready
+  fi
+) 9> /var/vcap/monit/ready.lock

--- a/scripts/dockerfiles/run.sh
+++ b/scripts/dockerfiles/run.sh
@@ -11,7 +11,7 @@ fi
 # Unmark the role. We may have this file from a previous run of the
 # role, i.e. this may be a restart. Ensure that we are not seen as
 # ready yet.
-rm -f /var/vcap/monit/ready /var/vcap/monit/ready.active
+rm -f /var/vcap/monit/ready /var/vcap/monit/ready.lock
 
 # When the container gets restarted, processes may end up with different pids
 find /run -name "*.pid" -delete
@@ -127,7 +127,7 @@ set -e
     done
     touch /var/vcap/monit/ready
   fi
-) 9> /var/vcap/monit/ready.active
+) 9> /var/vcap/monit/ready.lock
 EOF
         chmod ug+x /opt/hcf/post-start.sh
 

--- a/scripts/dockerfiles/run.sh
+++ b/scripts/dockerfiles/run.sh
@@ -8,6 +8,11 @@ EOL
 exit 0
 fi
 
+# Unmark the role. We may have this file from a previous run of the
+# role, i.e. this may be a restart. Ensure that we are not seen as
+# ready yet.
+rm -f /var/vcap/monit/ready /var/vcap/monit/ready.active
+
 # When the container gets restarted, processes may end up with different pids
 find /run -name "*.pid" -delete
 if [ -d /var/vcap/sys/run ]; then
@@ -85,6 +90,58 @@ done
         /var/vcap/jobs/{{ $job.Name }}/bin/run
     {{ end }}
 {{ else }}
+    # Run all the scripts called post-start, if any.
+    psp=$(find /var/vcap/jobs/*/bin -name post-start)
+
+    if [ "X$psp" != X ] ; then
+	# We have post-start scripts to run.
+
+	# We do this by adding a job to the monit configuration
+	# before invoking it. This actually trivial, we simply
+	# put a .monitrc file into the directory /var/vcap/monit/job
+	# and monit will pick it up on start.
+	#
+	# The trick is to make this new job ("PS") dependent on all
+	# the existing jobs (of the role). Because the monit we have
+	# has bugs in its dependency management our job's start
+	# command does the checking manually, parsing the output of
+	# `monit summary`.  We are also using `flock` to guard against
+	# monit starting the job multiple times (due to the checking
+	# itself or the called post-start scripts taking too long).
+	# The start command is a script we arrange to run all the
+	# post-start files. Its last action is setting the monitored
+	# marker file, completing things.
+
+
+	# Create the job script, runs all the post-start scripts
+	# found, then sets the marker.
+	cat > /opt/hcf/post-start.sh <<EOF
+#!/bin/bash
+set -e
+(
+  flock -n 9 || exit 1
+  notyet=\$(monit summary | tail -n+3 |grep -v 'Accessible\|Running'|wc -l)
+  if [ \$notyet -eq 1 ] ; then
+    for fname in ${psp} ; do
+      bash \$fname
+    done
+    touch /var/vcap/monit/ready
+  fi
+) 9> /var/vcap/monit/ready.active
+EOF
+        chmod ug+x /opt/hcf/post-start.sh
+
+	# Create the trivial configuration file for the new job. We
+	# keep using the standard timeout of 10 seconds here. The
+	# flock in the script guards against possible multiple
+	# invokations by monit.
+	cat > /var/vcap/monit/zomega.monitrc <<EOF
+check file zomega path /var/vcap/monit/ready
+  start program = "/opt/hcf/post-start.sh"
+EOF
+
+    fi
+
     # Replace bash with monit to handle both SIGTERM and SIGINT
     exec dumb-init -- monit -vI
 {{ end }}


### PR DESCRIPTION
Collapsed the history, dropped the transient monit, as per the last comment from yesterday.
The new form with a dynamically created job checking the dependencies and starting the post-start stuff when things are up worked out very well and looks to be much simpler.

Local tests ... All working.
