### PR TITLE
HCF-1167 make lint/format should fail on error

### DIFF
--- a/make/format
+++ b/make/format
@@ -2,16 +2,18 @@
 
 set -o errexit
 
+. make/include/colors.sh
+
+printf "%b==> Formatting %b\n" "${OK_COLOR}" "${ERROR_COLOR}"
+
 ISSUES=$(mktemp)
 
-trap "rm -f ${ISSUES}" HUP INT TERM
+trap "cat ${ISSUES} ; rm -f ${ISSUES}" EXIT
 
 go list -f '{{ .Dir }}' ./... | sed '/fissile[/]scripts/d ; /\/vendor\//d' | while read DIR; do
-    goimports -d -e ${DIR}/*.go | tee -a ${ISSUES}
+    goimports -d -e "${DIR}"/*.go >> "${ISSUES}"
 done
 
-ISSUE_COUNT=$(cat ${ISSUES} | wc -l)
+printf "%b" "${NO_COLOR}"
 
-rm -f ${ISSUES}
-
-test ${ISSUE_COUNT} -eq 0
+test ! -s "${ISSUES}"

--- a/make/include/colors.sh
+++ b/make/include/colors.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+NO_COLOR='\033[0m'
+OK_COLOR='\033[32;01m'
+ERROR_COLOR='\033[31;01m'
+WARN_COLOR='\033[33;01m'

--- a/make/lint
+++ b/make/lint
@@ -2,13 +2,18 @@
 
 set -o errexit
 
+. make/include/colors.sh
+
+printf "%b==> Linting%b\n" "${OK_COLOR}" "${ERROR_COLOR}"
+
 ISSUES=$(mktemp)
 
-trap "rm -f '${ISSUES}'" EXIT
+trap "cat ${ISSUES} ; rm -f ${ISSUES}" EXIT
 
 go list -f '{{ .Dir }}' ./... | sed '/fissile[/]scripts/d ; /\/vendor\//d ' | while read DIR; do
-    golint $(ls "${DIR}"/*.go | grep -v _generated.go) | tee -a "${ISSUES}"
+    golint $(ls "${DIR}"/*.go | grep -v _generated.go) >> "${ISSUES}"
 done
 
-# Check that the issues list is empty. (We fail with an error due to errexit)
+printf "%b" "${NO_COLOR}"
+
 test ! -s "${ISSUES}"


### PR DESCRIPTION
When the program (golint / goimports) reports an error — for example because they were not installed - we should correctly fail.

This fixes the issue by getting rid of the pipe so `errexit` is still in effect.  While we're there, get rid of the `wc` too, since we can just test for an empty file.  That means always removing the file during the trap, rather than early, which lets us unconditionally cat it too.

Also fixes problems identified by shellcheck.