### PR TITLE
HCF-1203 Use copytruncate when rotating logs

### DIFF
--- a/scripts/dockerfiles/rsyslog_conf/etc/logrotate.d/hcf
+++ b/scripts/dockerfiles/rsyslog_conf/etc/logrotate.d/hcf
@@ -4,5 +4,6 @@
   compress
   delaycompress
   copytruncate
-  size=10M
+  maxsize=10M
+  minsize=9M
 }

--- a/scripts/dockerfiles/rsyslog_conf/etc/logrotate.d/rsyslog
+++ b/scripts/dockerfiles/rsyslog_conf/etc/logrotate.d/rsyslog
@@ -1,14 +1,13 @@
 /var/log/syslog
 {
 	rotate 7
-	size 5M
+	maxsize=10M
+	minsize=9M
 	missingok
 	notifempty
 	delaycompress
 	compress
-	postrotate
-		reload rsyslog >/dev/null 2>&1 || true
-	endscript
+	copytruncate
 }
 
 /var/log/mail.info
@@ -25,13 +24,12 @@
 /var/log/messages
 {
 	rotate 4
-	size 5M
+	maxsize=10M
+	minsize=9M
 	missingok
 	notifempty
 	compress
 	delaycompress
 	sharedscripts
-	postrotate
-		reload rsyslog >/dev/null 2>&1 || true
-	endscript
+	copytruncate
 }


### PR DESCRIPTION
Use "copytruncate" for all logs other than the ones in /var/vcap (they're already rotated that way).
Use "minsize" and "maxsize" to better control when log rotation is triggered.