### PR TITLE
HCF-1212 Stop all processes when a container is stopped

### DIFF
--- a/builder/role_image_test.go
+++ b/builder/role_image_test.go
@@ -120,7 +120,7 @@ func TestGenerateRoleImageRunScript(t *testing.T) {
 	assert.Contains(string(runScriptContents), "bash /var/vcap/jobs/myrole/pre-start")
 	assert.NotContains(string(runScriptContents), "/opt/hcf/startup/var/vcap/jobs/myrole/pre-start")
 	assert.NotContains(string(runScriptContents), "/opt/hcf//startup/var/vcap/jobs/myrole/pre-start")
-	assert.Contains(string(runScriptContents), "exec dumb-init -- monit -vI")
+	assert.Contains(string(runScriptContents), "monit -vI &")
 
 	runScriptContents, err = roleImageBuilder.generateRunScript(rolesManifest.Roles[1])
 	assert.NoError(err)


### PR DESCRIPTION
Trap SIGTERM and manually run monit stop all and wait for all processes to be stopped.
When monit is stopped, it doesn't automatically stop the processes it takes care of.