### PR TITLE
[HCF-1238] Disable logging to dev/xconsole

### DIFF
--- a/scripts/dockerfiles/rsyslog_conf/etc/rsyslog.d/50-default.conf
+++ b/scripts/dockerfiles/rsyslog_conf/etc/rsyslog.d/50-default.conf
@@ -62,7 +62,7 @@ news.notice			-/var/log/news/news.notice
 # NOTE: adjust the list below, or you'll go crazy if you have a reasonably
 #      busy site..
 #
-daemon.*;mail.*;\
-	news.err;\
-	*.=debug;*.=info;\
-	*.=notice;*.=warn	|/dev/xconsole
+#daemon.*;mail.*;\
+#	news.err;\
+#	*.=debug;*.=info;\
+#	*.=notice;*.=warn	|/dev/xconsole


### PR DESCRIPTION
The definition caused messages like "action 'action 18' suspended, next retry is ...".
Because xconsole does not exist in a container.

Passed build, unit tests.
Images build with the change have the proper changed rsyslog configration
(checked under vagrant)