### PR TITLE
[HCF-1912] Use type reflection to prevent inner nodes of the dark opinions to be seen as dark.

### DIFF
--- a/model/job.go
+++ b/model/job.go
@@ -317,9 +317,12 @@ func (j *Job) getPropertiesForJob(opinions *opinions) (map[string]interface{}, e
 
 		darkValue, ok := getOpinionValue(darkOpinionsByString, keyPieces)
 		if ok {
-			if (darkValue == nil) ||
-				((reflect.TypeOf(darkValue).Kind() != reflect.Map) &&
-				(reflect.TypeOf(darkValue).Kind() != reflect.Array)) {
+			if darkValue == nil {
+				// Ignore dark opinions
+				continue
+			}
+			kind := reflect.TypeOf(darkValue).Kind()
+			if kind != reflect.Map && kind != reflect.Array {
 				// Ignore dark opinions
 				continue
 			}


### PR DESCRIPTION
Example: Making "uaa.clients.cf-usb.secret" dark does not mean that "uaa.clients" is dark.
This fix is required for https://github.com/hpcloud/hcf/pull/854
