### PR TITLE
Add generic error types for validation purpose

### DIFF
--- a/app/fissile.go
+++ b/app/fissile.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hpcloud/fissile/model"
 	"github.com/hpcloud/fissile/scripts/compilation"
 	"github.com/hpcloud/fissile/util"
+	"github.com/hpcloud/fissile/validation"
 
 	"github.com/fatih/color"
 	"github.com/hpcloud/stampy"
@@ -777,6 +778,11 @@ roleLoop:
 			}
 
 		case model.RoleTypeBosh:
+
+			if errs := validation.ValidateRoleRun(role.Run); len(errs) != 0 {
+				return fmt.Errorf(errs.Errors())
+			}
+
 			needsStorage := len(role.Run.PersistentVolumes) != 0 || len(role.Run.SharedVolumes) != 0
 
 			if role.HasTag("clustered") || needsStorage {

--- a/validation/errors.go
+++ b/validation/errors.go
@@ -1,0 +1,178 @@
+package validation
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Error is an implementation of the 'error' interface, which represents a
+// field-level validation error.
+type Error struct {
+	Type     ErrorType
+	Field    string
+	BadValue interface{}
+	Detail   string
+}
+
+// Error implements the error interface.
+func (v *Error) Error() string {
+	return fmt.Sprintf("%s: %s", v.Field, v.ErrorBody())
+}
+
+// ErrorBody returns the error message without the field name.  This is useful
+// for building nice-looking higher-level error reporting.
+func (v *Error) ErrorBody() string {
+	var s string
+	switch v.Type {
+	case ErrorTypeRequired, ErrorTypeForbidden, ErrorTypeTooLong, ErrorTypeInternal:
+		s = fmt.Sprintf("%s", v.Type)
+	default:
+		var bad string
+		badBytes, err := json.Marshal(v.BadValue)
+		if err != nil {
+			bad = err.Error()
+		} else {
+			bad = string(badBytes)
+		}
+		s = fmt.Sprintf("%s: %s", v.Type, bad)
+	}
+	if len(v.Detail) != 0 {
+		s += fmt.Sprintf(": %s", v.Detail)
+	}
+	return s
+}
+
+// ErrorType is a machine readable value providing more detail about why
+// a field is invalid.
+type ErrorType string
+
+const (
+	// ErrorTypeNotFound is used to report failure to find a requested value
+	// (e.g. looking up an ID).  See NotFound().
+	ErrorTypeNotFound ErrorType = "FieldValueNotFound"
+	// ErrorTypeRequired is used to report required values that are not
+	// provided (e.g. empty strings, null values, or empty arrays).  See
+	// Required().
+	ErrorTypeRequired ErrorType = "FieldValueRequired"
+	// ErrorTypeDuplicate is used to report collisions of values that must be
+	// unique (e.g. unique IDs).  See Duplicate().
+	ErrorTypeDuplicate ErrorType = "FieldValueDuplicate"
+	// ErrorTypeInvalid is used to report malformed values (e.g. failed regex
+	// match, too long, out of bounds).  See Invalid().
+	ErrorTypeInvalid ErrorType = "FieldValueInvalid"
+	// ErrorTypeNotSupported is used to report unknown values for enumerated
+	// fields (e.g. a list of valid values).  See NotSupported().
+	ErrorTypeNotSupported ErrorType = "FieldValueNotSupported"
+	// ErrorTypeForbidden is used to report valid (as per formatting rules)
+	// values which would be accepted under some conditions, but which are not
+	// permitted by the current conditions (such as security policy).  See
+	// Forbidden().
+	ErrorTypeForbidden ErrorType = "FieldValueForbidden"
+	// ErrorTypeTooLong is used to report that the given value is too long.
+	// This is similar to ErrorTypeInvalid, but the error will not include the
+	// too-long value.  See TooLong().
+	ErrorTypeTooLong ErrorType = "FieldValueTooLong"
+	// ErrorTypeInternal is used to report other errors that are not related
+	// to user input.  See InternalError().
+	ErrorTypeInternal ErrorType = "InternalError"
+)
+
+// String converts a ErrorType into its corresponding canonical error message.
+func (t ErrorType) String() string {
+	switch t {
+	case ErrorTypeNotFound:
+		return "Not found"
+	case ErrorTypeRequired:
+		return "Required value"
+	case ErrorTypeDuplicate:
+		return "Duplicate value"
+	case ErrorTypeInvalid:
+		return "Invalid value"
+	case ErrorTypeNotSupported:
+		return "Unsupported value"
+	case ErrorTypeForbidden:
+		return "Forbidden"
+	case ErrorTypeTooLong:
+		return "Too long"
+	case ErrorTypeInternal:
+		return "Internal error"
+	default:
+		panic(fmt.Sprintf("unrecognized validation error: %q", string(t)))
+	}
+}
+
+// NotFound returns a *Error indicating "value not found".  This is
+// used to report failure to find a requested value (e.g. looking up an ID).
+func NotFound(field string, value interface{}) *Error {
+	return &Error{ErrorTypeNotFound, field, value, ""}
+}
+
+// Required returns a *Error indicating "value required".  This is used
+// to report required values that are not provided (e.g. empty strings, null
+// values, or empty arrays).
+func Required(field string, detail string) *Error {
+	return &Error{ErrorTypeRequired, field, "", detail}
+}
+
+// Duplicate returns a *Error indicating "duplicate value".  This is
+// used to report collisions of values that must be unique (e.g. names or IDs).
+func Duplicate(field string, value interface{}) *Error {
+	return &Error{ErrorTypeDuplicate, field, value, ""}
+}
+
+// Invalid returns a *Error indicating "invalid value".  This is used
+// to report malformed values (e.g. failed regex match, too long, out of bounds).
+func Invalid(field string, value interface{}, detail string) *Error {
+	return &Error{ErrorTypeInvalid, field, value, detail}
+}
+
+// NotSupported returns a *Error indicating "unsupported value".
+// This is used to report unknown values for enumerated fields (e.g. a list of
+// valid values).
+func NotSupported(field string, value interface{}, validValues []string) *Error {
+	detail := ""
+	if validValues != nil && len(validValues) > 0 {
+		detail = "supported values: " + strings.Join(validValues, ", ")
+	}
+	return &Error{ErrorTypeNotSupported, field, value, detail}
+}
+
+// Forbidden returns a *Error indicating "forbidden".  This is used to
+// report valid (as per formatting rules) values which would be accepted under
+// some conditions, but which are not permitted by current conditions (e.g.
+// security policy).
+func Forbidden(field string, detail string) *Error {
+	return &Error{ErrorTypeForbidden, field, "", detail}
+}
+
+// TooLong returns a *Error indicating "too long".  This is used to
+// report that the given value is too long.  This is similar to
+// Invalid, but the returned error will not include the too-long
+// value.
+func TooLong(field string, value interface{}, maxLength int) *Error {
+	return &Error{ErrorTypeTooLong, field, value, fmt.Sprintf("must have at most %d characters", maxLength)}
+}
+
+// InternalError returns a *Error indicating "internal error".  This is used
+// to signal that an error was found that was not directly related to user
+// input.  The err argument must be non-nil.
+func InternalError(field string, err error) *Error {
+	return &Error{ErrorTypeInternal, field, nil, err.Error()}
+}
+
+// ErrorList holds a set of Errors.  It is plausible that we might one day have
+// non-field errors in this same umbrella package, but for now we don't, so
+// we can keep it simple and leave ErrorList here.
+type ErrorList []*Error
+
+// Errors implements the error interface.
+func (v *ErrorList) Errors() string {
+	var values []string
+
+	for _, item := range *v {
+		values = append(values, item.Error())
+	}
+
+	return strings.Join(values, "\n")
+}

--- a/validation/errors_test.go
+++ b/validation/errors_test.go
@@ -1,0 +1,76 @@
+package validation
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMakeFuncs(t *testing.T) {
+	testCases := []struct {
+		fn       func() *Error
+		expected ErrorType
+	}{
+		{
+			func() *Error { return Invalid("a", "b", "c") },
+			ErrorTypeInvalid,
+		},
+		{
+			func() *Error { return NotSupported("a", "b", nil) },
+			ErrorTypeNotSupported,
+		},
+		{
+			func() *Error { return Duplicate("a", "b") },
+			ErrorTypeDuplicate,
+		},
+		{
+			func() *Error { return NotFound("a", "b") },
+			ErrorTypeNotFound,
+		},
+		{
+			func() *Error { return Required("a", "b") },
+			ErrorTypeRequired,
+		},
+		{
+			func() *Error { return InternalError("a", fmt.Errorf("b")) },
+			ErrorTypeInternal,
+		},
+	}
+
+	for _, testCase := range testCases {
+		err := testCase.fn()
+		assert.Equal(t, err.Type, testCase.expected)
+	}
+}
+
+func TestErrorUsefulMessage(t *testing.T) {
+	s := Invalid("foo", "bar", "deet").Error()
+	for _, part := range []string{"foo", "bar", "deet", ErrorTypeInvalid.String()} {
+		assert.Contains(t, s, part)
+	}
+
+	type complicated struct {
+		Baz   int
+		Qux   string
+		Inner interface{}
+		KV    map[string]int
+	}
+	s = Invalid(
+		"foo",
+		&complicated{
+			Baz:   1,
+			Qux:   "aoeu",
+			Inner: &complicated{Qux: "asdf"},
+			KV:    map[string]int{"Billy": 2},
+		},
+		"detail",
+	).Error()
+	for _, part := range []string{
+		"foo", ErrorTypeInvalid.String(),
+		"Baz", "Qux", "Inner", "KV", "detail",
+		"1", "aoeu", "asdf", "Billy", "2",
+	} {
+		assert.Contains(t, s, part)
+	}
+}

--- a/validation/rules.go
+++ b/validation/rules.go
@@ -1,0 +1,26 @@
+package validation
+
+import "fmt"
+
+const (
+	// UDP protocol
+	UDP = `UDP`
+	// TCP protocol
+	TCP = `TCP`
+)
+
+// IsValidPortNum tests that the argument is a valid, non-zero port number.
+func IsValidPortNum(port int) error {
+	if 1 <= port && port <= 65535 {
+		return nil
+	}
+	return fmt.Errorf(`must be between %d and %d, inclusive`, 1, 65535)
+}
+
+// IsValidProtocol tests that the argument is TCP or UDP.
+func IsValidProtocol(protocol string) error {
+	if protocol != TCP && protocol != UDP {
+		return fmt.Errorf(`must be TCP or UDP`)
+	}
+	return nil
+}

--- a/validation/validation.go
+++ b/validation/validation.go
@@ -1,0 +1,72 @@
+package validation
+
+import (
+	"fmt"
+	"strconv"
+
+	roles "github.com/hpcloud/fissile/model"
+)
+
+// ValidateNonnegativeField validates that given value is not negative.
+func ValidateNonnegativeField(value int64, field string) ErrorList {
+	allErrs := ErrorList{}
+	if value < 0 {
+		allErrs = append(allErrs, Invalid(field, value, `must be greater than or equal to 0`))
+	}
+	return allErrs
+}
+
+// ValidatePort validates that given value is valid and in range 0 - 65535.
+func ValidatePort(port string, field string) ErrorList {
+	allErrs := ErrorList{}
+
+	portInt, err := strconv.Atoi(port)
+	if err != nil {
+		allErrs = append(allErrs, Invalid(field, port, `invalid syntax`))
+	} else {
+
+		if msg := IsValidPortNum(portInt); msg != nil {
+			allErrs = append(allErrs, Invalid(field, portInt, msg.Error()))
+		}
+	}
+
+	return allErrs
+}
+
+// ValidateProtocol validates that given value belongs to supported protocols
+func ValidateProtocol(protocol string, field string) ErrorList {
+	allErrs := ErrorList{}
+
+	if err := IsValidProtocol(protocol); err != nil {
+		allErrs = append(allErrs, NotSupported(field, protocol, []string{TCP, UDP}))
+
+	}
+
+	return allErrs
+}
+
+// ValidateRoleRun tests whether required fields in the RoleRun are set.
+func ValidateRoleRun(run *roles.RoleRun) ErrorList {
+	allErrs := ErrorList{}
+
+	if run == nil {
+		return append(allErrs, Required("run", ""))
+	}
+
+	allErrs = append(allErrs, ValidateNonnegativeField(int64(run.Memory), `run.memory`)...)
+	allErrs = append(allErrs, ValidateNonnegativeField(int64(run.VirtualCPUs), `run.virtual-cpus`)...)
+
+	for i := range run.ExposedPorts {
+
+		if run.ExposedPorts[i].Name == "" {
+			allErrs = append(allErrs, Required(`run.exposed-ports.name`, ""))
+		}
+
+		allErrs = append(allErrs, ValidatePort(run.ExposedPorts[i].External, fmt.Sprintf(`run.exposed-ports[%s].external`, run.ExposedPorts[i].Name))...)
+		allErrs = append(allErrs, ValidatePort(run.ExposedPorts[i].Internal, fmt.Sprintf(`run.exposed-ports[%s].internal`, run.ExposedPorts[i].Name))...)
+
+		allErrs = append(allErrs, ValidateProtocol(run.ExposedPorts[i].Protocol, fmt.Sprintf(`run.exposed-ports[%s].protocol`, run.ExposedPorts[i].Name))...)
+	}
+
+	return allErrs
+}

--- a/validation/validation_test.go
+++ b/validation/validation_test.go
@@ -1,0 +1,56 @@
+package validation
+
+import (
+	"testing"
+
+	roles "github.com/hpcloud/fissile/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateRoleRun(t *testing.T) {
+	newRun := func(memory int, cpu int, name string, externalPort string, internalPort string, protocol string) *roles.RoleRun {
+		return &roles.RoleRun{
+			VirtualCPUs: cpu,
+			Memory:      memory,
+			ExposedPorts: []*roles.RoleRunExposedPort{{Name: name, External: externalPort,
+				Internal: internalPort, Protocol: protocol,
+			}},
+		}
+	}
+
+	var (
+		validRun      = newRun(10, 2, "test", "1", "2", "UDP")
+		wrongProtocol = newRun(10, 2, "test", "1", "2", "AA")
+		wrongPorts    = newRun(10, 2, "test", "0", "-1", "UDP")
+		wrongParse    = newRun(10, 2, "test", "0", "qq", "UDP")
+		negativeField = newRun(-10, 2, "test", "1", "2", "UDP")
+	)
+
+	tests := map[string]struct {
+		run            *roles.RoleRun
+		isValid        bool
+		expectedErrors string
+	}{
+		"nil":            {nil, false, "run: Required value"},
+		"valid":          {validRun, true, ``},
+		"wrong protocol": {wrongProtocol, false, "run.exposed-ports[test].protocol: Unsupported value: \"AA\": supported values: TCP, UDP"},
+		"wrong ports": {wrongPorts, false, "run.exposed-ports[test].external: Invalid value: 0: must be between 1 and 65535, inclusive\n" +
+			"run.exposed-ports[test].internal: Invalid value: -1: must be between 1 and 65535, inclusive"},
+		"wrong parse": {wrongParse, false, "run.exposed-ports[test].external: Invalid value: 0: must be between 1 and 65535, inclusive\n" +
+			"run.exposed-ports[test].internal: Invalid value: \"qq\": invalid syntax"},
+		"negative field": {negativeField, false, `run.memory: Invalid value: -10: must be greater than or equal to 0`},
+	}
+
+	for name, tc := range tests {
+		errs := ValidateRoleRun(tc.run)
+		if tc.isValid && len(errs) > 0 {
+			t.Errorf("%v: unexpected error: %v", name, errs)
+		}
+		if !tc.isValid && len(errs) == 0 {
+			t.Errorf("%v: unexpected non-error", name)
+		}
+		if !tc.isValid && len(errs) > 0 {
+			assert.Equal(t, tc.expectedErrors, errs.Errors())
+		}
+	}
+}


### PR DESCRIPTION
This PR introduces generic error types which can be put into chain in validation methods.
It helps collect all errors during validation and display them in the end.

For example when you execute `fissile build kube`:
```
  run:    
    scaling:
      min: 1
      max: 3    
    memory: 256    
    virtual-cpus: 4    
    exposed-ports:
    - name:                  #missing name
      protocol: aaaa      #wrong protocol
      external:               # missing port
      internal: 4222   
      public: false    
    - name: nats-routes      
      protocol: TCP      
      external: 4223      
      internal: 4223      
      public: false

```
you get

```
$ fissile build kube
...
run.exposed-ports.name: Required value
run.exposed-ports[].external: Invalid value: "": invalid syntax
run.exposed-ports[].protocol: Unsupported value: "aaaa": supported values: TCP, UDP

```
