### PR TITLE
Remove some mentions of HCF

### DIFF
--- a/builder/base_image_test.go
+++ b/builder/base_image_test.go
@@ -57,7 +57,7 @@ func TestBaseImageNewDockerPopulator(t *testing.T) {
 			assert.Contains(string(rawContents), "BUNDLE_GEMFILE")
 		},
 		"monitrc.erb": func(rawContents []byte) {
-			assert.Contains(string(rawContents), "hcf.monit.password")
+			assert.Contains(string(rawContents), "fissile.monit.password")
 		},
 	}
 

--- a/model/job.go
+++ b/model/job.go
@@ -228,7 +228,7 @@ func (j *Job) loadJobSpec() (err error) {
 }
 
 // MergeSpec is used to merge temporary spec patches into each job. otherJob should only be
-// the hcf/patch-properties job.  The code assumes package and property objects are immutable,
+// the fissile-compat/patch-properties job.  The code assumes package and property objects are immutable,
 // as they're now being shared across jobs. Also, when specified packages or properties are
 // specified in the "other" job, that one takes precedence.
 func (j *Job) MergeSpec(otherJob *Job) {

--- a/scripts/compilation/ubuntu-prerequisites.sh
+++ b/scripts/compilation/ubuntu-prerequisites.sh
@@ -29,4 +29,4 @@ apt-get update
 apt-get install -o Dpkg::Options::="--force-confnew" -f -y --force-yes --no-install-recommends $debs
 
 # Add the vcap:vcap user to match CF
-useradd -m --comment 'hcf user' vcap
+useradd -m --comment 'fissile user' vcap

--- a/scripts/dockerfiles/Dockerfile-base
+++ b/scripts/dockerfiles/Dockerfile-base
@@ -1,6 +1,6 @@
 FROM {{ .BaseImage }}
 
-MAINTAINER hcf@hpe.com
+MAINTAINER cloudfoundry@suse.example
 
 # Install prerequisites
 # Install monit and other dependencies
@@ -8,7 +8,7 @@ MAINTAINER hcf@hpe.com
 # Enable resolvconf updates
 # Setup default locale and timezone
 
-RUN useradd -m --comment 'hcf user' vcap && \
+RUN useradd -m --comment 'fissile user' vcap && \
     groupadd --system admin && \
     usermod -G admin,adm,audio,cdrom,dialout,floppy,video,dip,plugdev vcap && \
     apt-get update && \

--- a/scripts/dockerfiles/Dockerfile-role
+++ b/scripts/dockerfiles/Dockerfile-role
@@ -1,7 +1,7 @@
 FROM {{ index . "base_image" }}
 
 {{ if not .dev }}
-MAINTAINER hcf@hpe.com
+MAINTAINER cloudfoundry@suse.example
 {{ end }}
 
 LABEL "role"="{{ .role.Name }}" "version"="{{ .image_version }}"

--- a/scripts/dockerfiles/monitrc.erb
+++ b/scripts/dockerfiles/monitrc.erb
@@ -6,9 +6,9 @@ set logfile /var/vcap/monit/monit.log
 # remote access is read-only and accessible using the "knowable" credentials 
 # provided by the user. We're afraid of exposing writable access to remote clients
 # using a non-TLS enabled connection.
-set httpd port <%= p("hcf.monit.port") %> and use address 0.0.0.0
+set httpd port <%= p("fissile.monit.port") %> and use address 0.0.0.0
   allow "<%= SecureRandom.hex %>":"<%= SecureRandom.hex %>"
-  allow "<%= p("hcf.monit.user") %>":"<%= p("hcf.monit.password") %>" read-only
+  allow "<%= p("fissile.monit.user") %>":"<%= p("fissile.monit.password") %>" read-only
 
 include /etc/monit/monitrc.d/cron
 include /etc/monit/monitrc.d/rsyslog


### PR DESCRIPTION
We should make the name generic (right now, `fissile-compat-release`, and `fissile.*` for the BOSH properties).

I did not change /opt/hcf paths; that is expected to come later as it is more likely to have issues.