### PR TITLE
Add ability to build a subset of things

### DIFF
--- a/app/fissile.go
+++ b/app/fissile.go
@@ -328,7 +328,7 @@ func (f *Fissile) Compile(repository, targetPath, roleManifestPath, metricsPath 
 		return fmt.Errorf("Error creating a new compilator: %s", err.Error())
 	}
 
-	roles, err := f.selectRolesToBuild(roleManifest.Roles, roleNames)
+	roles, err := roleManifest.SelectRoles(roleNames)
 	if err != nil {
 		return fmt.Errorf("Error selecting packages to build: %s", err.Error())
 	}
@@ -449,33 +449,6 @@ func (f *Fissile) GeneratePackagesRoleImage(repository string, roleManifest *mod
 	return nil
 }
 
-func (f *Fissile) selectRolesToBuild(roles model.Roles, roleNames []string) (model.Roles, error) {
-	var results model.Roles
-
-	if len(roleNames) == 0 {
-		// No role names specified, assume all roles
-		return roles, nil
-	}
-
-	var missingRoles []string
-	roleMap := make(map[string]*model.Role, len(roles))
-	for _, role := range roles {
-		roleMap[strings.ToLower(role.Name)] = role
-	}
-	for _, roleName := range roleNames {
-		if role, ok := roleMap[strings.ToLower(roleName)]; ok {
-			results = append(results, role)
-		} else {
-			missingRoles = append(missingRoles, roleName)
-		}
-	}
-	if len(missingRoles) > 0 {
-		return nil, fmt.Errorf("Some roles are unknown: %v", missingRoles)
-	}
-
-	return results, nil
-}
-
 // GenerateRoleImages generates all role images using dev releases
 func (f *Fissile) GenerateRoleImages(targetPath, repository, metricsPath string, noBuild, force bool, roleNames []string, workerCount int, rolesManifestPath, compiledPackagesPath, lightManifestPath, darkManifestPath string) error {
 	if len(f.releases) == 0 {
@@ -503,7 +476,7 @@ func (f *Fissile) GenerateRoleImages(targetPath, repository, metricsPath string,
 		return err
 	}
 
-	roles, err := f.selectRolesToBuild(roleManifest.Roles, roleNames)
+	roles, err := roleManifest.SelectRoles(roleNames)
 	if err != nil {
 		return err
 	}

--- a/app/fissile.go
+++ b/app/fissile.go
@@ -298,7 +298,7 @@ func (f *Fissile) collectProperties() map[string]map[string]map[string]interface
 }
 
 // Compile will compile a list of dev BOSH releases
-func (f *Fissile) Compile(repository, targetPath, roleManifestPath, metricsPath string, workerCount int) error {
+func (f *Fissile) Compile(repository, targetPath, roleManifestPath, metricsPath string, roleNames []string, workerCount int) error {
 	if len(f.releases) == 0 {
 		return fmt.Errorf("Releases not loaded")
 	}
@@ -328,7 +328,12 @@ func (f *Fissile) Compile(repository, targetPath, roleManifestPath, metricsPath 
 		return fmt.Errorf("Error creating a new compilator: %s", err.Error())
 	}
 
-	if err := comp.Compile(workerCount, f.releases, roleManifest); err != nil {
+	roles, err := f.selectRolesToBuild(roleManifest.Roles, roleNames)
+	if err != nil {
+		return fmt.Errorf("Error selecting packages to build: %s", err.Error())
+	}
+
+	if err := comp.Compile(workerCount, f.releases, roles); err != nil {
 		return fmt.Errorf("Error compiling packages: %s", err.Error())
 	}
 

--- a/app/fissile_test.go
+++ b/app/fissile_test.go
@@ -178,7 +178,7 @@ func TestDevDiffConfigurations(t *testing.T) {
 	assert.False(ok)
 }
 
-func TestFisileSelectRolesToBuild(t *testing.T) {
+func TestFissileSelectRolesToBuild(t *testing.T) {
 	assert := assert.New(t)
 	ui := termui.New(&bytes.Buffer{}, ioutil.Discard, nil)
 	workDir, err := os.Getwd()
@@ -220,7 +220,7 @@ func TestFisileSelectRolesToBuild(t *testing.T) {
 	}
 
 	for _, sample := range testSamples {
-		results, err := f.selectRolesToBuild(roleManifest.Roles, sample.roleNames)
+		results, err := roleManifest.SelectRoles(sample.roleNames)
 		if sample.err != "" {
 			assert.EqualError(err, sample.err, "while testing %v", sample.roleNames)
 		} else {

--- a/builder/packages_image.go
+++ b/builder/packages_image.go
@@ -136,17 +136,17 @@ func (p *PackagesImageBuilder) determinePackagesLayerBaseImage(packages model.Pa
 }
 
 // NewDockerPopulator returns a function which can populate a tar stream with the docker context to build the packages layer image with
-func (p *PackagesImageBuilder) NewDockerPopulator(roleManifest *model.RoleManifest, forceBuildAll bool) func(*tar.Writer) error {
+func (p *PackagesImageBuilder) NewDockerPopulator(roles model.Roles, forceBuildAll bool) func(*tar.Writer) error {
 	return func(tarWriter *tar.Writer) error {
 		var err error
-		if len(roleManifest.Roles) == 0 {
+		if len(roles) == 0 {
 			return fmt.Errorf("No roles to build")
 		}
 
 		// Collect compiled packages
 		foundFingerprints := make(map[string]struct{})
 		var packages model.Packages
-		for _, role := range roleManifest.Roles {
+		for _, role := range roles {
 			for _, job := range role.Jobs {
 				for _, pkg := range job.Packages {
 					if _, ok := foundFingerprints[pkg.Fingerprint]; ok {
@@ -229,9 +229,9 @@ func (p *PackagesImageBuilder) generateDockerfile(baseImage string, packages mod
 }
 
 // GetRolePackageImageName generates a docker image name for the amalgamation for a role image
-func (p *PackagesImageBuilder) GetRolePackageImageName(roleManifest *model.RoleManifest) string {
+func (p *PackagesImageBuilder) GetRolePackageImageName(roleManifest *model.RoleManifest, roles model.Roles) string {
 	return util.SanitizeDockerName(fmt.Sprintf("%s-role-packages:%s",
 		p.repository,
-		roleManifest.GetRoleManifestDevPackageVersion(p.fissileVersion),
+		roleManifest.GetRoleManifestDevPackageVersion(roles, p.fissileVersion),
 	))
 }

--- a/builder/packages_image_test.go
+++ b/builder/packages_image_test.go
@@ -97,7 +97,7 @@ func TestNewDockerPopulator(t *testing.T) {
 
 	tarFile := &bytes.Buffer{}
 
-	tarPopulator := packagesImageBuilder.NewDockerPopulator(rolesManifest, false)
+	tarPopulator := packagesImageBuilder.NewDockerPopulator(rolesManifest.Roles, false)
 	tarWriter := tar.NewWriter(tarFile)
 	assert.NoError(tarPopulator(tarWriter))
 	assert.NoError(tarWriter.Close())

--- a/cmd/build-images.go
+++ b/cmd/build-images.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"strings"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -8,6 +10,7 @@ import (
 var (
 	flagBuildImagesNoBuild       bool
 	flagBuildImagesForce         bool
+	flagBuildImagesRoles         string
 	flagPatchPropertiesDirective string
 )
 
@@ -40,6 +43,7 @@ from other specs.  At most one is allowed.  Its syntax is --patch-properties-rel
 
 		flagBuildImagesNoBuild = viper.GetBool("no-build")
 		flagBuildImagesForce = viper.GetBool("force")
+		flagBuildImagesRoles = viper.GetString("roles")
 		flagPatchPropertiesDirective = viper.GetString("patch-properties-release")
 
 		err := fissile.SetPatchPropertiesDirective(flagPatchPropertiesDirective)
@@ -62,6 +66,7 @@ from other specs.  At most one is allowed.  Its syntax is --patch-properties-rel
 			flagMetrics,
 			flagBuildImagesNoBuild,
 			flagBuildImagesForce,
+			strings.Split(flagBuildImagesRoles, ","),
 			flagWorkers,
 			flagRoleManifest,
 			workPathCompilationDir,
@@ -93,6 +98,14 @@ func init() {
 		"P",
 		"",
 		"Used to designate a \"patch-properties\" psuedo-job in a particular release.  Format: RELEASE/JOB.",
+	)
+
+	// viper is busted w/ string slice, https://github.com/spf13/viper/issues/200
+	buildImagesCmd.PersistentFlags().StringP(
+		"roles",
+		"",
+		"",
+		"Build only images with the given role name; comma separated.",
 	)
 
 	viper.BindPFlags(buildImagesCmd.PersistentFlags())

--- a/cmd/build-images.go
+++ b/cmd/build-images.go
@@ -66,7 +66,7 @@ from other specs.  At most one is allowed.  Its syntax is --patch-properties-rel
 			flagMetrics,
 			flagBuildImagesNoBuild,
 			flagBuildImagesForce,
-			strings.Split(flagBuildImagesRoles, ","),
+			strings.FieldsFunc(flagBuildImagesRoles, func(r rune) bool { return r == ',' }),
 			flagWorkers,
 			flagRoleManifest,
 			workPathCompilationDir,

--- a/cmd/build-images.go
+++ b/cmd/build-images.go
@@ -77,6 +77,9 @@ from other specs.  At most one is allowed.  Its syntax is --patch-properties-rel
 }
 
 func init() {
+	v := viper.New()
+	initViper(v)
+
 	buildCmd.AddCommand(buildImagesCmd)
 
 	buildImagesCmd.PersistentFlags().BoolP(
@@ -108,5 +111,5 @@ func init() {
 		"Build only images with the given role name; comma separated.",
 	)
 
-	viper.BindPFlags(buildImagesCmd.PersistentFlags())
+	v.BindPFlags(buildImagesCmd.PersistentFlags())
 }

--- a/cmd/build-packages.go
+++ b/cmd/build-packages.go
@@ -45,7 +45,7 @@ compiled once.
 			workPathCompilationDir,
 			flagRoleManifest,
 			flagMetrics,
-			strings.Split(flagBuildPackagesRoles, ","),
+			strings.FieldsFunc(flagBuildPackagesRoles, func(r rune) bool { return r == ',' }),
 			flagWorkers,
 		)
 	},

--- a/cmd/build-packages.go
+++ b/cmd/build-packages.go
@@ -52,6 +52,9 @@ compiled once.
 }
 
 func init() {
+	v := viper.New()
+	initViper(v)
+
 	buildCmd.AddCommand(buildPackagesCmd)
 
 	// viper is busted w/ string slice, https://github.com/spf13/viper/issues/200
@@ -62,5 +65,5 @@ func init() {
 		"Build only packages for the given role names; comma separated.",
 	)
 
-	viper.BindPFlags(buildPackagesCmd.PersistentFlags())
+	v.BindPFlags(buildPackagesCmd.PersistentFlags())
 }

--- a/cmd/build-packages.go
+++ b/cmd/build-packages.go
@@ -1,7 +1,10 @@
 package cmd
 
 import (
+	"strings"
+
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 // buildPackagesCmd represents the packages command
@@ -25,6 +28,8 @@ compiled once.
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 
+		flagBuildPackagesRoles := viper.GetString("roles")
+
 		err := fissile.LoadReleases(
 			flagRelease,
 			flagReleaseName,
@@ -40,6 +45,7 @@ compiled once.
 			workPathCompilationDir,
 			flagRoleManifest,
 			flagMetrics,
+			strings.Split(flagBuildPackagesRoles, ","),
 			flagWorkers,
 		)
 	},
@@ -47,4 +53,14 @@ compiled once.
 
 func init() {
 	buildCmd.AddCommand(buildPackagesCmd)
+
+	// viper is busted w/ string slice, https://github.com/spf13/viper/issues/200
+	buildPackagesCmd.PersistentFlags().StringP(
+		"roles",
+		"",
+		"",
+		"Build only packages for the given role names; comma separated.",
+	)
+
+	viper.BindPFlags(buildPackagesCmd.PersistentFlags())
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -170,20 +170,25 @@ func init() {
 
 // initConfig reads in config file and ENV variables if set.
 func initConfig() {
+	initViper(viper.GetViper())
+}
+func initViper(v *viper.Viper) {
 	if cfgFile != "" { // enable ability to specify config file via flag
-		viper.SetConfigFile(cfgFile)
+		v.SetConfigFile(cfgFile)
 	}
 
-	viper.SetEnvPrefix("FISSILE")
+	v.SetEnvPrefix("FISSILE")
 
-	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
-	viper.SetConfigName(".fissile") // name of config file (without extension)
-	viper.AddConfigPath("$HOME")    // adding home directory as first search path
-	viper.AutomaticEnv()            // read in environment variables that match
+	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+	v.SetConfigName(".fissile") // name of config file (without extension)
+	v.AddConfigPath("$HOME")    // adding home directory as first search path
+	v.AutomaticEnv()            // read in environment variables that match
 
 	// If a config file is found, read it in.
-	if err := viper.ReadInConfig(); err == nil {
-		fmt.Println("Using config file:", viper.ConfigFileUsed())
+	if err := v.ReadInConfig(); err == nil {
+		if v == viper.GetViper() {
+			fmt.Println("Using config file:", viper.ConfigFileUsed())
+		}
 	}
 }
 

--- a/compilator/compilator_test.go
+++ b/compilator/compilator_test.go
@@ -216,7 +216,7 @@ func TestCompilationRoleManifest(t *testing.T) {
 	waitCh := make(chan struct{})
 	errCh := make(chan error)
 	go func() {
-		errCh <- c.Compile(1, []*model.Release{release}, roleManifest)
+		errCh <- c.Compile(1, []*model.Release{release}, roleManifest.Roles)
 	}()
 	go func() {
 		// `libevent` is a dependency of `tor` and will be compiled first

--- a/model/roles.go
+++ b/model/roles.go
@@ -275,9 +275,9 @@ func LoadRoleManifest(manifestFilePath string, releases []*Release) (*RoleManife
 }
 
 // GetRoleManifestDevPackageVersion gets the aggregate signature of all the packages
-func (m *RoleManifest) GetRoleManifestDevPackageVersion(extra string) string {
+func (m *RoleManifest) GetRoleManifestDevPackageVersion(roles Roles, extra string) string {
 	// Make sure our roles are sorted, to have consistent output
-	roles := append(Roles{}, m.Roles...)
+	roles = append(Roles{}, roles...)
 	sort.Sort(roles)
 
 	hasher := sha1.New()

--- a/model/roles.go
+++ b/model/roles.go
@@ -295,6 +295,30 @@ func (m *RoleManifest) LookupRole(roleName string) *Role {
 	return m.rolesByName[roleName]
 }
 
+// SelectRoles will find only the given roles in the role manifest
+func (m *RoleManifest) SelectRoles(roleNames []string) (Roles, error) {
+	if len(roleNames) == 0 {
+		// No role names specified, assume all roles
+		return m.Roles, nil
+	}
+
+	var results Roles
+	var missingRoles []string
+
+	for _, roleName := range roleNames {
+		if role, ok := m.rolesByName[roleName]; ok {
+			results = append(results, role)
+		} else {
+			missingRoles = append(missingRoles, roleName)
+		}
+	}
+	if len(missingRoles) > 0 {
+		return nil, fmt.Errorf("Some roles are unknown: %v", missingRoles)
+	}
+
+	return results, nil
+}
+
 // GetScriptPaths returns the paths to the startup / post configgin scripts for a role
 func (r *Role) GetScriptPaths() map[string]string {
 	result := map[string]string{}

--- a/model/roles_test.go
+++ b/model/roles_test.go
@@ -235,11 +235,13 @@ func TestGetRoleManifestDevPackageVersion(t *testing.T) {
 	}
 
 	firstManifest := &RoleManifest{Roles: Roles{refRole, altRole}}
-	firstHash := firstManifest.GetRoleManifestDevPackageVersion("")
-	secondHash := (&RoleManifest{Roles: Roles{altRole, refRole}}).GetRoleManifestDevPackageVersion("")
+	firstHash := firstManifest.GetRoleManifestDevPackageVersion(firstManifest.Roles, "")
+	secondManifest := &RoleManifest{Roles: Roles{altRole, refRole}}
+	secondHash := secondManifest.GetRoleManifestDevPackageVersion(secondManifest.Roles, "")
 	assert.Equal(firstHash, secondHash, "role manifest hash should be independent of role order")
-	jobOrderHash := (&RoleManifest{Roles: Roles{wrongJobOrder, altRole}}).GetRoleManifestDevPackageVersion("")
+	jobOrderManifest := &RoleManifest{Roles: Roles{wrongJobOrder, altRole}}
+	jobOrderHash := jobOrderManifest.GetRoleManifestDevPackageVersion(jobOrderManifest.Roles, "")
 	assert.NotEqual(firstHash, jobOrderHash, "role manifest hash should be dependent on job order")
-	differentExtraHash := firstManifest.GetRoleManifestDevPackageVersion("some string")
+	differentExtraHash := firstManifest.GetRoleManifestDevPackageVersion(firstManifest.Roles, "some string")
 	assert.NotEqual(firstHash, differentExtraHash, "role manifest hash should be dependent on extra string")
 }


### PR DESCRIPTION
This allows you to build only the packages required for a named selection of roles, or their images, instead of doing everything at once.

This should make it easier to CI things.

I'm introducing sub-vipers to work around issues where it gets confused if multiple subcommands use the same flag name.