### PR TITLE
Fix env variables going into kube pods

### DIFF
--- a/app/fissile.go
+++ b/app/fissile.go
@@ -798,7 +798,7 @@ func (f *Fissile) GenerateKube(rolesManifestPath, outputDir, repository, registr
 	}
 
 	for _, role := range rolesManifest.Roles {
-		if isDevRole(role) {
+		if role.IsDevRole() {
 			continue
 		}
 
@@ -868,14 +868,4 @@ func (f *Fissile) GenerateKube(rolesManifestPath, outputDir, repository, registr
 	}
 
 	return nil
-}
-
-func isDevRole(role *model.Role) bool {
-	for _, tag := range role.Tags {
-		switch tag {
-		case "dev-only":
-			return true
-		}
-	}
-	return false
 }

--- a/app/fissile.go
+++ b/app/fissile.go
@@ -797,13 +797,9 @@ func (f *Fissile) GenerateKube(rolesManifestPath, outputDir, repository, registr
 		UseMemoryLimits: useMemoryLimits,
 	}
 
-roleLoop:
 	for _, role := range rolesManifest.Roles {
-		for _, tag := range role.Tags {
-			switch tag {
-			case "dev-only":
-				continue roleLoop
-			}
+		if isDevRole(role) {
+			continue
 		}
 
 		roleTypeDir := filepath.Join(outputDir, string(role.Type))
@@ -872,4 +868,14 @@ roleLoop:
 	}
 
 	return nil
+}
+
+func isDevRole(role *model.Role) bool {
+	for _, tag := range role.Tags {
+		switch tag {
+		case "dev-only":
+			return true
+		}
+	}
+	return false
 }

--- a/kube/pod_test.go
+++ b/kube/pod_test.go
@@ -144,7 +144,7 @@ func TestPodGetEnvVars(t *testing.T) {
 		},
 	}
 
-	role.Configuration.Templates["property.some-property"] = "((SOME_VAR))"
+	role.Configuration.Templates["properties.some-property"] = "((SOME_VAR))"
 
 	samples := []struct {
 		desc     string

--- a/model/mustache.go
+++ b/model/mustache.go
@@ -31,8 +31,7 @@ func (r *Role) GetVariablesForRole() (ConfigurationVariableSlice, error) {
 		for _, property := range job.Properties {
 			propertyName := fmt.Sprintf("properties.%s", property.Name)
 
-			if template, ok := r.rolesManifest.Configuration.Templates[propertyName]; ok {
-
+			if template, ok := r.Configuration.Templates[propertyName]; ok {
 				varsInTemplate, err := parseTemplate(template)
 				if err != nil {
 					return nil, err
@@ -43,22 +42,6 @@ func (r *Role) GetVariablesForRole() (ConfigurationVariableSlice, error) {
 						configs[confVar.Name] = confVar
 					}
 				}
-			}
-		}
-	}
-
-	// TODO we might want to exclude env vars that are from templates that are
-	// overwritten by per-role configs
-	for _, template := range r.Configuration.Templates {
-		varsInTemplate, err := parseTemplate(template)
-
-		if err != nil {
-			return nil, err
-		}
-
-		for _, envVar := range varsInTemplate {
-			if confVar, ok := configsDictionary[envVar]; ok {
-				configs[confVar.Name] = confVar
 			}
 		}
 	}

--- a/model/roles.go
+++ b/model/roles.go
@@ -774,3 +774,15 @@ func validateNonTemplates(roleManifest *RoleManifest) validation.ErrorList {
 
 	return allErrs
 }
+
+// IsDevRole tests if the role is tagged for development, or not. It
+// returns true for development-roles, and false otherwise.
+func (r *Role) IsDevRole() bool {
+	for _, tag := range r.Tags {
+		switch tag {
+		case "dev-only":
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Ref https://trello.com/c/MwLhXpr3/14-env-vars-are-not-detected-properly-for-pods-it-looks-like-the-pods-get-more-than-they-need