### PR TITLE
Allow manifest private variables

### DIFF
--- a/app/validation.go
+++ b/app/validation.go
@@ -1,12 +1,13 @@
 package app
 
 import (
-	//"fmt"
-	//"strings"
+	"fmt"
+	"strings"
 
 	"github.com/hpcloud/fissile/model"
 	"github.com/hpcloud/fissile/validation"
-	//"github.com/fatih/color"
+
+	"github.com/fatih/color"
 )
 
 // validateManifestAndOpinions applies a series of checks to the role
@@ -16,304 +17,304 @@ import (
 func (f *Fissile) validateManifestAndOpinions(roleManifest *model.RoleManifest, opinions *model.Opinions) validation.ErrorList {
 	allErrs := validation.ErrorList{}
 
-	// boshPropertyDefaultsAndJobs := f.collectPropertyDefaults()
-	// darkOpinions := model.FlattenOpinions(opinions.Dark)
-	// lightOpinions := model.FlattenOpinions(opinions.Light)
-	// manifestProperties := collectManifestProperties(roleManifest)
+	boshPropertyDefaultsAndJobs := f.collectPropertyDefaults()
+	darkOpinions := model.FlattenOpinions(opinions.Dark)
+	lightOpinions := model.FlattenOpinions(opinions.Light)
+	manifestProperties := collectManifestProperties(roleManifest)
 
-	// // All properties must be defined in a BOSH release
-	// allErrs = append(allErrs, checkForUndefinedBOSHProperties("role-manifest",
-	// 	manifestProperties, boshPropertyDefaultsAndJobs)...)
+	// All properties must be defined in a BOSH release
+	allErrs = append(allErrs, checkForUndefinedBOSHProperties("role-manifest",
+		manifestProperties, boshPropertyDefaultsAndJobs)...)
 
-	// // All light opinions must exists in a bosh release
-	// allErrs = append(allErrs, checkForUndefinedBOSHProperties("light opinion",
-	// 	lightOpinions, boshPropertyDefaultsAndJobs)...)
+	// All light opinions must exists in a bosh release
+	allErrs = append(allErrs, checkForUndefinedBOSHProperties("light opinion",
+		lightOpinions, boshPropertyDefaultsAndJobs)...)
 
-	// // All dark opinions must exists in a bosh release
-	// allErrs = append(allErrs, checkForUndefinedBOSHProperties("dark opinion",
-	// 	darkOpinions, boshPropertyDefaultsAndJobs)...)
+	// All dark opinions must exists in a bosh release
+	allErrs = append(allErrs, checkForUndefinedBOSHProperties("dark opinion",
+		darkOpinions, boshPropertyDefaultsAndJobs)...)
 
-	// // All dark opinions must be configured as templates
-	// allErrs = append(allErrs, checkForUntemplatedDarkOpinions(darkOpinions,
-	// 	manifestProperties)...)
+	// All dark opinions must be configured as templates
+	allErrs = append(allErrs, checkForUntemplatedDarkOpinions(darkOpinions,
+		manifestProperties)...)
 
-	// // No dark opinions must have defaults in light opinions
-	// allErrs = append(allErrs, checkForDarkInTheLight(darkOpinions, lightOpinions)...)
+	// No dark opinions must have defaults in light opinions
+	allErrs = append(allErrs, checkForDarkInTheLight(darkOpinions, lightOpinions)...)
 
-	// // No duplicates must exist between role manifest and light
-	// // opinions
-	// allErrs = append(allErrs, checkForDuplicatesBetweenManifestAndLight(lightOpinions, roleManifest)...)
+	// No duplicates must exist between role manifest and light
+	// opinions
+	allErrs = append(allErrs, checkForDuplicatesBetweenManifestAndLight(lightOpinions, roleManifest)...)
 
-	// // All bosh properties in a release should have the same
-	// // default across jobs -- WARNING only, not error
-	// f.checkBOSHDefaults(boshPropertyDefaultsAndJobs)
+	// All bosh properties in a release should have the same
+	// default across jobs -- WARNING only, not error
+	f.checkBOSHDefaults(boshPropertyDefaultsAndJobs)
 
-	// // All light opinions should differ from their defaults in the
-	// // BOSH releases
-	// allErrs = append(allErrs, f.checkLightDefaults(lightOpinions,
-	// 	boshPropertyDefaultsAndJobs)...)
+	// All light opinions should differ from their defaults in the
+	// BOSH releases
+	allErrs = append(allErrs, f.checkLightDefaults(lightOpinions,
+		boshPropertyDefaultsAndJobs)...)
 
 	return allErrs
 }
 
-// // Check that the given 'properties' are all defined in a 'bosh'
-// // release.
-// func checkForUndefinedBOSHProperties(label string, properties map[string]string, bosh propertyDefaults) validation.ErrorList {
-// 	// All provided properties must be defined in a BOSH release
-// 	allErrs := validation.ErrorList{}
+// Check that the given 'properties' are all defined in a 'bosh'
+// release.
+func checkForUndefinedBOSHProperties(label string, properties map[string]string, bosh propertyDefaults) validation.ErrorList {
+	// All provided properties must be defined in a BOSH release
+	allErrs := validation.ErrorList{}
 
-// 	for property := range properties {
-// 		// Ignore specials (without the "properties." prefix)
-// 		if !strings.HasPrefix(property, "properties.") {
-// 			continue
-// 		}
-// 		p := strings.TrimPrefix(property, "properties.")
+	for property := range properties {
+		// Ignore specials (without the "properties." prefix)
+		if !strings.HasPrefix(property, "properties.") {
+			continue
+		}
+		p := strings.TrimPrefix(property, "properties.")
 
-// 		if _, ok := bosh[p]; !ok {
-// 			// The property as is was not found. This is
-// 			// not necessarily an error. The "property"
-// 			// may actually part of the value for a
-// 			// structured (hash) property. To determine
-// 			// this we walk the chain of parents to see if
-// 			// any of them exist, and report an error only
-// 			// if none of them do.
+		if _, ok := bosh[p]; !ok {
+			// The property as is was not found. This is
+			// not necessarily an error. The "property"
+			// may actually part of the value for a
+			// structured (hash) property. To determine
+			// this we walk the chain of parents to see if
+			// any of them exist, and report an error only
+			// if none of them do.
 
-// 			if checkParentsOfUndefined(p, bosh) {
-// 				continue
-// 			}
+			if checkParentsOfUndefined(p, bosh) {
+				continue
+			}
 
-// 			allErrs = append(allErrs, validation.NotFound(
-// 				fmt.Sprintf("%s '%s'", label, p), "In any BOSH release"))
-// 		}
-// 	}
+			allErrs = append(allErrs, validation.NotFound(
+				fmt.Sprintf("%s '%s'", label, p), "In any BOSH release"))
+		}
+	}
 
-// 	return allErrs
-// }
+	return allErrs
+}
 
-// // checkParentsOfUndefined walks the chain of parents for `p` from the
-// // bottom up and checks if any of them exist. The elements of the
-// // chain are separated by dots.
-// func checkParentsOfUndefined(p string, bosh propertyDefaults) bool {
-// 	at := strings.LastIndex(p, ".")
+// checkParentsOfUndefined walks the chain of parents for `p` from the
+// bottom up and checks if any of them exist. The elements of the
+// chain are separated by dots.
+func checkParentsOfUndefined(p string, bosh propertyDefaults) bool {
+	at := strings.LastIndex(p, ".")
 
-// 	for at >= 0 {
-// 		// While there is a dot in the property name we have a
-// 		// parent to check the existence of
+	for at >= 0 {
+		// While there is a dot in the property name we have a
+		// parent to check the existence of
 
-// 		tail := p[at:]
-// 		parent := strings.TrimSuffix(p, tail)
+		tail := p[at:]
+		parent := strings.TrimSuffix(p, tail)
 
-// 		if pInfo, ok := bosh[parent]; ok {
-// 			// We have a possible parent. Look if that
-// 			// candidate may be a hash. If not our
-// 			// property cannot be valid.
+		if pInfo, ok := bosh[parent]; ok {
+			// We have a possible parent. Look if that
+			// candidate may be a hash. If not our
+			// property cannot be valid.
 
-// 			if pInfo.maybeHash {
-// 				return true
-// 			}
+			if pInfo.maybeHash {
+				return true
+			}
 
-// 			return false
-// 		}
+			return false
+		}
 
-// 		p = parent
-// 		at = strings.LastIndex(p, ".")
-// 	}
+		p = parent
+		at = strings.LastIndex(p, ".")
+	}
 
-// 	return false
-// }
+	return false
+}
 
-// // collectManifestProperties returns a map merging the global and
-// // per-role properties/templates into a single structure.
-// func collectManifestProperties(roleManifest *model.RoleManifest) map[string]string {
-// 	properties := make(map[string]string)
+// collectManifestProperties returns a map merging the global and
+// per-role properties/templates into a single structure.
+func collectManifestProperties(roleManifest *model.RoleManifest) map[string]string {
+	properties := make(map[string]string)
 
-// 	// Per-role properties
-// 	for _, role := range roleManifest.Roles {
-// 		for property, template := range role.Configuration.Templates {
-// 			properties[property] = template
-// 		}
-// 	}
+	// Per-role properties
+	for _, role := range roleManifest.Roles {
+		for property, template := range role.Configuration.Templates {
+			properties[property] = template
+		}
+	}
 
-// 	// And the global properties
-// 	for property, template := range roleManifest.Configuration.Templates {
-// 		properties[property] = template
-// 	}
+	// And the global properties
+	for property, template := range roleManifest.Configuration.Templates {
+		properties[property] = template
+	}
 
-// 	return properties
-// }
+	return properties
+}
 
-// // checkForUntemplatedDarkOpinions reports all dark opinions which are
-// // not configured as templates in the manifest.
-// func checkForUntemplatedDarkOpinions(dark map[string]string, properties map[string]string) validation.ErrorList {
-// 	allErrs := validation.ErrorList{}
+// checkForUntemplatedDarkOpinions reports all dark opinions which are
+// not configured as templates in the manifest.
+func checkForUntemplatedDarkOpinions(dark map[string]string, properties map[string]string) validation.ErrorList {
+	allErrs := validation.ErrorList{}
 
-// 	for property := range dark {
-// 		if _, ok := properties[property]; ok {
-// 			continue
-// 		}
-// 		allErrs = append(allErrs, validation.NotFound(
-// 			property, "Dark opinion is missing template in role-manifest"))
-// 	}
+	for property := range dark {
+		if _, ok := properties[property]; ok {
+			continue
+		}
+		allErrs = append(allErrs, validation.NotFound(
+			property, "Dark opinion is missing template in role-manifest"))
+	}
 
-// 	return allErrs
-// }
+	return allErrs
+}
 
-// // checkForDarkInTheLight reports all dark opinions which have
-// // defaults in light opinions, which is forbidden
-// func checkForDarkInTheLight(dark map[string]string, light map[string]string) validation.ErrorList {
-// 	allErrs := validation.ErrorList{}
+// checkForDarkInTheLight reports all dark opinions which have
+// defaults in light opinions, which is forbidden
+func checkForDarkInTheLight(dark map[string]string, light map[string]string) validation.ErrorList {
+	allErrs := validation.ErrorList{}
 
-// 	for property := range dark {
-// 		if _, ok := light[property]; !ok {
-// 			continue
-// 		}
-// 		allErrs = append(allErrs, validation.Forbidden(
-// 			property, "Dark opinion found in light opinions"))
-// 	}
+	for property := range dark {
+		if _, ok := light[property]; !ok {
+			continue
+		}
+		allErrs = append(allErrs, validation.Forbidden(
+			property, "Dark opinion found in light opinions"))
+	}
 
-// 	return allErrs
-// }
+	return allErrs
+}
 
-// // checkForDuplicatesBetweenManifestAndLight reports all duplicates
-// // between role manifest and light opinions, i.e. properties defined
-// // in both.
-// func checkForDuplicatesBetweenManifestAndLight(light map[string]string, roleManifest *model.RoleManifest) validation.ErrorList {
-// 	allErrs := validation.ErrorList{}
+// checkForDuplicatesBetweenManifestAndLight reports all duplicates
+// between role manifest and light opinions, i.e. properties defined
+// in both.
+func checkForDuplicatesBetweenManifestAndLight(light map[string]string, roleManifest *model.RoleManifest) validation.ErrorList {
+	allErrs := validation.ErrorList{}
 
-// 	check := make(map[string]struct{})
+	check := make(map[string]struct{})
 
-// 	// The global properties, ...
-// 	for property, template := range roleManifest.Configuration.Templates {
-// 		allErrs = append(allErrs, checkForDuplicateProperty("configuration.templates", property, template, light, true)...)
-// 		check[property] = struct{}{}
-// 	}
+	// The global properties, ...
+	for property, template := range roleManifest.Configuration.Templates {
+		allErrs = append(allErrs, checkForDuplicateProperty("configuration.templates", property, template, light, true)...)
+		check[property] = struct{}{}
+	}
 
-// 	// ... then the per-role properties
-// 	for _, role := range roleManifest.Roles {
-// 		prefix := fmt.Sprintf("roles[%s].configuration.templates", role.Name)
+	// ... then the per-role properties
+	for _, role := range roleManifest.Roles {
+		prefix := fmt.Sprintf("roles[%s].configuration.templates", role.Name)
 
-// 		for property, template := range role.Configuration.Templates {
-// 			// Skip over duplicates of the global
-// 			// properties in the per-role data, we already
-// 			// checked them, see above.
-// 			if _, ok := check[property]; ok {
-// 				continue
-// 			}
-// 			allErrs = append(allErrs, checkForDuplicateProperty(prefix, property, template, light, false)...)
-// 		}
-// 	}
+		for property, template := range role.Configuration.Templates {
+			// Skip over duplicates of the global
+			// properties in the per-role data, we already
+			// checked them, see above.
+			if _, ok := check[property]; ok {
+				continue
+			}
+			allErrs = append(allErrs, checkForDuplicateProperty(prefix, property, template, light, false)...)
+		}
+	}
 
-// 	return allErrs
-// }
+	return allErrs
+}
 
-// // checkForDuplicateProperty performs the check for a property (of the
-// // manifest) duplicated in the light opinions.
-// func checkForDuplicateProperty(prefix, property, value string, light map[string]string, conflicts bool) validation.ErrorList {
-// 	allErrs := validation.ErrorList{}
+// checkForDuplicateProperty performs the check for a property (of the
+// manifest) duplicated in the light opinions.
+func checkForDuplicateProperty(prefix, property, value string, light map[string]string, conflicts bool) validation.ErrorList {
+	allErrs := validation.ErrorList{}
 
-// 	lightvalue, ok := light[property]
-// 	if !ok {
-// 		return allErrs
-// 	}
+	lightvalue, ok := light[property]
+	if !ok {
+		return allErrs
+	}
 
-// 	if lightvalue == value {
-// 		return append(allErrs, validation.Forbidden(fmt.Sprintf("%s[%s]", prefix, property),
-// 			"Role-manifest duplicates opinion, remove from manifest"))
-// 	}
+	if lightvalue == value {
+		return append(allErrs, validation.Forbidden(fmt.Sprintf("%s[%s]", prefix, property),
+			"Role-manifest duplicates opinion, remove from manifest"))
+	}
 
-// 	if conflicts {
-// 		return append(allErrs, validation.Forbidden(fmt.Sprintf("%s[%s]", prefix, property),
-// 			"Role-manifest overrides opinion, remove opinion"))
-// 	}
+	if conflicts {
+		return append(allErrs, validation.Forbidden(fmt.Sprintf("%s[%s]", prefix, property),
+			"Role-manifest overrides opinion, remove opinion"))
+	}
 
-// 	return allErrs
-// }
+	return allErrs
+}
 
-// // checkBOSHDefaults reports all properties which were given differing
-// // defaults across BOSH releases and the jobs inside.
-// func (f *Fissile) checkBOSHDefaults(pd propertyDefaults) {
-// 	for property, pInfo := range pd {
-// 		// Ignore properties with a single default across all definitions.
-// 		if len(pInfo.defaults) == 1 {
-// 			continue
-// 		}
+// checkBOSHDefaults reports all properties which were given differing
+// defaults across BOSH releases and the jobs inside.
+func (f *Fissile) checkBOSHDefaults(pd propertyDefaults) {
+	for property, pInfo := range pd {
+		// Ignore properties with a single default across all definitions.
+		if len(pInfo.defaults) == 1 {
+			continue
+		}
 
-// 		f.UI.Printf("%s: Property %s has %s defaults:\n",
-// 			color.YellowString("Warning"),
-// 			color.YellowString(property),
-// 			color.YellowString(fmt.Sprintf("%d", len(pInfo.defaults))))
+		f.UI.Printf("%s: Property %s has %s defaults:\n",
+			color.YellowString("Warning"),
+			color.YellowString(property),
+			color.YellowString(fmt.Sprintf("%d", len(pInfo.defaults))))
 
-// 		maxlen := 0
-// 		for defaultv := range pInfo.defaults {
-// 			ds := fmt.Sprintf("%v", defaultv)
-// 			if len(ds) > maxlen {
-// 				maxlen = len(ds)
-// 			}
-// 		}
+		maxlen := 0
+		for defaultv := range pInfo.defaults {
+			ds := fmt.Sprintf("%v", defaultv)
+			if len(ds) > maxlen {
+				maxlen = len(ds)
+			}
+		}
 
-// 		leftjustified := fmt.Sprintf("%%-%ds", maxlen)
+		leftjustified := fmt.Sprintf("%%-%ds", maxlen)
 
-// 		for defaultv, jobs := range pInfo.defaults {
-// 			ds := fmt.Sprintf("%v", defaultv)
-// 			if len(jobs) == 1 {
-// 				job := jobs[0]
-// 				f.UI.Printf("- Default %s: Release %s, job %s\n",
-// 					color.CyanString(fmt.Sprintf(leftjustified, ds)),
-// 					color.CyanString(job.Release.Name),
-// 					color.CyanString(job.Name))
-// 			} else {
-// 				f.UI.Printf("- Default %s:\n", color.CyanString(ds))
-// 				for _, job := range jobs {
-// 					f.UI.Printf("  - Release %s, job %s\n",
-// 						color.CyanString(job.Release.Name),
-// 						color.CyanString(job.Name))
-// 				}
-// 			}
-// 		}
-// 	}
-// }
+		for defaultv, jobs := range pInfo.defaults {
+			ds := fmt.Sprintf("%v", defaultv)
+			if len(jobs) == 1 {
+				job := jobs[0]
+				f.UI.Printf("- Default %s: Release %s, job %s\n",
+					color.CyanString(fmt.Sprintf(leftjustified, ds)),
+					color.CyanString(job.Release.Name),
+					color.CyanString(job.Name))
+			} else {
+				f.UI.Printf("- Default %s:\n", color.CyanString(ds))
+				for _, job := range jobs {
+					f.UI.Printf("  - Release %s, job %s\n",
+						color.CyanString(job.Release.Name),
+						color.CyanString(job.Name))
+				}
+			}
+		}
+	}
+}
 
-// // checkLightDefaults reports all light opinions whose value is
-// // identical to their default in the BOSH releases
-// func (f *Fissile) checkLightDefaults(light map[string]string, pd propertyDefaults) validation.ErrorList {
+// checkLightDefaults reports all light opinions whose value is
+// identical to their default in the BOSH releases
+func (f *Fissile) checkLightDefaults(light map[string]string, pd propertyDefaults) validation.ErrorList {
 
-// 	// light :: (property.name -> value-of-opinion)
-// 	// pd    :: (property.name -> (default.string -> [*job...])
-// 	allErrs := validation.ErrorList{}
+	// light :: (property.name -> value-of-opinion)
+	// pd    :: (property.name -> (default.string -> [*job...])
+	allErrs := validation.ErrorList{}
 
-// 	for property, opinion := range light {
-// 		// Ignore specials (without the "properties." prefix)
-// 		if !strings.HasPrefix(property, "properties.") {
-// 			continue
-// 		}
-// 		p := strings.TrimPrefix(property, "properties.")
+	for property, opinion := range light {
+		// Ignore specials (without the "properties." prefix)
+		if !strings.HasPrefix(property, "properties.") {
+			continue
+		}
+		p := strings.TrimPrefix(property, "properties.")
 
-// 		// Ignore unknown/undefined property
-// 		pInfo, ok := pd[p]
-// 		if !ok {
-// 			continue
-// 		}
+		// Ignore unknown/undefined property
+		pInfo, ok := pd[p]
+		if !ok {
+			continue
+		}
 
-// 		// Ignore properties with ambigous defaults. Warn however.
-// 		if len(pInfo.defaults) > 1 {
-// 			f.UI.Printf("light opinion %s ignored, %s\n",
-// 				color.YellowString(p),
-// 				color.YellowString("ambiguous default"))
-// 			continue
-// 		}
+		// Ignore properties with ambigous defaults. Warn however.
+		if len(pInfo.defaults) > 1 {
+			f.UI.Printf("light opinion %s ignored, %s\n",
+				color.YellowString(p),
+				color.YellowString("ambiguous default"))
+			continue
+		}
 
-// 		// len(pInfo.defaults) == 1 --> This loop will run only once
-// 		// Is there a better (more direct?) way to get the
-// 		// single key, i.e. default from the map ?
-// 		for thedefault := range pInfo.defaults {
-// 			if opinion != thedefault {
-// 				continue
-// 			}
-// 			allErrs = append(allErrs, validation.Forbidden(property,
-// 				fmt.Sprintf("Light opinion matches default of '%v'",
-// 					thedefault)))
-// 		}
-// 	}
+		// len(pInfo.defaults) == 1 --> This loop will run only once
+		// Is there a better (more direct?) way to get the
+		// single key, i.e. default from the map ?
+		for thedefault := range pInfo.defaults {
+			if opinion != thedefault {
+				continue
+			}
+			allErrs = append(allErrs, validation.Forbidden(property,
+				fmt.Sprintf("Light opinion matches default of '%v'",
+					thedefault)))
+		}
+	}
 
-// 	return allErrs
-// }
+	return allErrs
+}

--- a/app/validation_test.go
+++ b/app/validation_test.go
@@ -1,135 +1,135 @@
 package app
 
-// import (
-// 	"bytes"
-// 	"io/ioutil"
-// 	"os"
-// 	"path/filepath"
-// 	"testing"
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
 
-// 	"github.com/hpcloud/fissile/model"
-// 	"github.com/hpcloud/termui"
-// 	"github.com/stretchr/testify/assert"
-// )
+	"github.com/hpcloud/fissile/model"
+	"github.com/hpcloud/termui"
+	"github.com/stretchr/testify/assert"
+)
 
-// func TestValidation(t *testing.T) {
-// 	ui := termui.New(&bytes.Buffer{}, ioutil.Discard, nil)
-// 	assert := assert.New(t)
+func TestValidation(t *testing.T) {
+	ui := termui.New(&bytes.Buffer{}, ioutil.Discard, nil)
+	assert := assert.New(t)
 
-// 	workDir, err := os.Getwd()
-// 	assert.NoError(err)
+	workDir, err := os.Getwd()
+	assert.NoError(err)
 
-// 	torReleasePath := filepath.Join(workDir, "../test-assets/tor-boshrelease")
-// 	torReleasePathBoshCache := filepath.Join(torReleasePath, "bosh-cache")
-// 	rolesManifestPath := filepath.Join(workDir, "../test-assets/role-manifests/tor-validation-issues.yml")
-// 	lightManifestPath := filepath.Join(workDir, "../test-assets/test-opinions/opinions.yml")
-// 	darkManifestPath := filepath.Join(workDir, "../test-assets/test-opinions/dark-opinions.yml")
-// 	f := NewFissileApplication(".", ui)
+	torReleasePath := filepath.Join(workDir, "../test-assets/tor-boshrelease")
+	torReleasePathBoshCache := filepath.Join(torReleasePath, "bosh-cache")
+	rolesManifestPath := filepath.Join(workDir, "../test-assets/role-manifests/tor-validation-issues.yml")
+	lightManifestPath := filepath.Join(workDir, "../test-assets/test-opinions/opinions.yml")
+	darkManifestPath := filepath.Join(workDir, "../test-assets/test-opinions/dark-opinions.yml")
+	f := NewFissileApplication(".", ui)
 
-// 	err = f.LoadReleases([]string{torReleasePath}, []string{""}, []string{""}, torReleasePathBoshCache)
-// 	assert.NoError(err)
+	err = f.LoadReleases([]string{torReleasePath}, []string{""}, []string{""}, torReleasePathBoshCache)
+	assert.NoError(err)
 
-// 	roleManifest, err := model.LoadRoleManifest(rolesManifestPath, f.releases)
-// 	assert.NoError(err)
+	roleManifest, err := model.LoadRoleManifest(rolesManifestPath, f.releases)
+	assert.NoError(err)
 
-// 	opinions, err := model.NewOpinions(lightManifestPath, darkManifestPath)
-// 	assert.NoError(err)
+	opinions, err := model.NewOpinions(lightManifestPath, darkManifestPath)
+	assert.NoError(err)
 
-// 	errs := f.validateManifestAndOpinions(roleManifest, opinions)
+	errs := f.validateManifestAndOpinions(roleManifest, opinions)
 
-// 	actual := errs.Errors()
-// 	allExpected := []string{
-// 		// checkForUndefinedBOSHProperties light
-// 		`light opinion 'tor.opinion': Not found: "In any BOSH release"`,
-// 		`light opinion 'tor.int_opinion': Not found: "In any BOSH release"`,
-// 		`light opinion 'tor.masked_opinion': Not found: "In any BOSH release"`,
-// 		// checkForUndefinedBOSHProperties dark
-// 		`dark opinion 'tor.dark-opinion': Not found: "In any BOSH release"`,
-// 		`dark opinion 'tor.masked_opinion': Not found: "In any BOSH release"`,
-// 		// checkForUndefinedBOSHProperties manifest
-// 		`role-manifest 'fox': Not found: "In any BOSH release"`,
-// 		// checkForUntemplatedDarkOpinions
-// 		`properties.tor.dark-opinion: Not found: "Dark opinion is missing template in role-manifest"`,
-// 		`properties.tor.masked_opinion: Not found: "Dark opinion is missing template in role-manifest"`,
-// 		// checkForDarkInTheLight
-// 		`properties.tor.masked_opinion: Forbidden: Dark opinion found in light opinions`,
-// 		// checkForDuplicatesBetweenManifestAndLight
-// 		`configuration.templates[properties.tor.hostname]: Forbidden: Role-manifest overrides opinion, remove opinion`,
-// 		`roles[myrole].configuration.templates[properties.tor.bogus]: Forbidden: Role-manifest duplicates opinion, remove from manifest`,
-// 		// checkForUndefinedBOSHProperties light, manifest - For the bogus property used above for checkOverridden
-// 		`role-manifest 'tor.bogus': Not found: "In any BOSH release"`,
-// 		`light opinion 'tor.bogus': Not found: "In any BOSH release"`,
-// 		`properties.tor.hostname: Forbidden: Light opinion matches default of 'localhost'`,
+	actual := errs.Errors()
+	allExpected := []string{
+		// checkForUndefinedBOSHProperties light
+		`light opinion 'tor.opinion': Not found: "In any BOSH release"`,
+		`light opinion 'tor.int_opinion': Not found: "In any BOSH release"`,
+		`light opinion 'tor.masked_opinion': Not found: "In any BOSH release"`,
+		// checkForUndefinedBOSHProperties dark
+		`dark opinion 'tor.dark-opinion': Not found: "In any BOSH release"`,
+		`dark opinion 'tor.masked_opinion': Not found: "In any BOSH release"`,
+		// checkForUndefinedBOSHProperties manifest
+		`role-manifest 'fox': Not found: "In any BOSH release"`,
+		// checkForUntemplatedDarkOpinions
+		`properties.tor.dark-opinion: Not found: "Dark opinion is missing template in role-manifest"`,
+		`properties.tor.masked_opinion: Not found: "Dark opinion is missing template in role-manifest"`,
+		// checkForDarkInTheLight
+		`properties.tor.masked_opinion: Forbidden: Dark opinion found in light opinions`,
+		// checkForDuplicatesBetweenManifestAndLight
+		`configuration.templates[properties.tor.hostname]: Forbidden: Role-manifest overrides opinion, remove opinion`,
+		`roles[myrole].configuration.templates[properties.tor.bogus]: Forbidden: Role-manifest duplicates opinion, remove from manifest`,
+		// checkForUndefinedBOSHProperties light, manifest - For the bogus property used above for checkOverridden
+		`role-manifest 'tor.bogus': Not found: "In any BOSH release"`,
+		`light opinion 'tor.bogus': Not found: "In any BOSH release"`,
+		`properties.tor.hostname: Forbidden: Light opinion matches default of 'localhost'`,
 
-// 		// `XXX`, // Trigger a fail which shows the contents of `actual`. Also template for new assertions.
-// 	}
-// 	for _, expected := range allExpected {
-// 		assert.Contains(actual, expected)
-// 	}
-// 	assert.Len(errs, len(allExpected))
-// }
+		// `XXX`, // Trigger a fail which shows the contents of `actual`. Also template for new assertions.
+	}
+	for _, expected := range allExpected {
+		assert.Contains(actual, expected)
+	}
+	assert.Len(errs, len(allExpected))
+}
 
-// func TestValidationOk(t *testing.T) {
-// 	ui := termui.New(&bytes.Buffer{}, ioutil.Discard, nil)
-// 	assert := assert.New(t)
+func TestValidationOk(t *testing.T) {
+	ui := termui.New(&bytes.Buffer{}, ioutil.Discard, nil)
+	assert := assert.New(t)
 
-// 	workDir, err := os.Getwd()
-// 	assert.NoError(err)
+	workDir, err := os.Getwd()
+	assert.NoError(err)
 
-// 	torReleasePath := filepath.Join(workDir, "../test-assets/tor-boshrelease")
-// 	torReleasePathBoshCache := filepath.Join(torReleasePath, "bosh-cache")
-// 	rolesManifestPath := filepath.Join(workDir, "../test-assets/role-manifests/tor-validation-ok.yml")
-// 	lightManifestPath := filepath.Join(workDir, "../test-assets/test-opinions/good-opinions.yml")
-// 	darkManifestPath := filepath.Join(workDir, "../test-assets/test-opinions/good-dark-opinions.yml")
+	torReleasePath := filepath.Join(workDir, "../test-assets/tor-boshrelease")
+	torReleasePathBoshCache := filepath.Join(torReleasePath, "bosh-cache")
+	rolesManifestPath := filepath.Join(workDir, "../test-assets/role-manifests/tor-validation-ok.yml")
+	lightManifestPath := filepath.Join(workDir, "../test-assets/test-opinions/good-opinions.yml")
+	darkManifestPath := filepath.Join(workDir, "../test-assets/test-opinions/good-dark-opinions.yml")
 
-// 	f := NewFissileApplication(".", ui)
+	f := NewFissileApplication(".", ui)
 
-// 	err = f.LoadReleases([]string{torReleasePath}, []string{""}, []string{""}, torReleasePathBoshCache)
-// 	assert.NoError(err)
+	err = f.LoadReleases([]string{torReleasePath}, []string{""}, []string{""}, torReleasePathBoshCache)
+	assert.NoError(err)
 
-// 	roleManifest, err := model.LoadRoleManifest(rolesManifestPath, f.releases)
-// 	assert.NoError(err)
+	roleManifest, err := model.LoadRoleManifest(rolesManifestPath, f.releases)
+	assert.NoError(err)
 
-// 	opinions, err := model.NewOpinions(lightManifestPath, darkManifestPath)
-// 	assert.NoError(err)
+	opinions, err := model.NewOpinions(lightManifestPath, darkManifestPath)
+	assert.NoError(err)
 
-// 	errs := f.validateManifestAndOpinions(roleManifest, opinions)
+	errs := f.validateManifestAndOpinions(roleManifest, opinions)
 
-// 	assert.Empty(errs)
-// }
+	assert.Empty(errs)
+}
 
-// func TestValidationHash(t *testing.T) {
-// 	ui := termui.New(&bytes.Buffer{}, ioutil.Discard, nil)
-// 	assert := assert.New(t)
+func TestValidationHash(t *testing.T) {
+	ui := termui.New(&bytes.Buffer{}, ioutil.Discard, nil)
+	assert := assert.New(t)
 
-// 	workDir, err := os.Getwd()
-// 	assert.NoError(err)
+	workDir, err := os.Getwd()
+	assert.NoError(err)
 
-// 	torReleasePath := filepath.Join(workDir, "../test-assets/tor-boshrelease")
-// 	torReleasePathBoshCache := filepath.Join(torReleasePath, "bosh-cache")
-// 	rolesManifestPath := filepath.Join(workDir, "../test-assets/role-manifests/hashmat.yml")
-// 	lightManifestPath := filepath.Join(workDir, "../test-assets/test-opinions/hashmat-light.yml")
-// 	darkManifestPath := filepath.Join(workDir, "../test-assets/test-opinions/hashmat-dark.yml")
-// 	f := NewFissileApplication(".", ui)
+	torReleasePath := filepath.Join(workDir, "../test-assets/tor-boshrelease")
+	torReleasePathBoshCache := filepath.Join(torReleasePath, "bosh-cache")
+	rolesManifestPath := filepath.Join(workDir, "../test-assets/role-manifests/hashmat.yml")
+	lightManifestPath := filepath.Join(workDir, "../test-assets/test-opinions/hashmat-light.yml")
+	darkManifestPath := filepath.Join(workDir, "../test-assets/test-opinions/hashmat-dark.yml")
+	f := NewFissileApplication(".", ui)
 
-// 	err = f.LoadReleases([]string{torReleasePath}, []string{""}, []string{""}, torReleasePathBoshCache)
-// 	assert.NoError(err)
+	err = f.LoadReleases([]string{torReleasePath}, []string{""}, []string{""}, torReleasePathBoshCache)
+	assert.NoError(err)
 
-// 	roleManifest, err := model.LoadRoleManifest(rolesManifestPath, f.releases)
-// 	assert.NoError(err)
+	roleManifest, err := model.LoadRoleManifest(rolesManifestPath, f.releases)
+	assert.NoError(err)
 
-// 	opinions, err := model.NewOpinions(lightManifestPath, darkManifestPath)
-// 	assert.NoError(err)
+	opinions, err := model.NewOpinions(lightManifestPath, darkManifestPath)
+	assert.NoError(err)
 
-// 	errs := f.validateManifestAndOpinions(roleManifest, opinions)
+	errs := f.validateManifestAndOpinions(roleManifest, opinions)
 
-// 	actual := errs.Errors()
-// 	allExpected := []string{
-// 		`role-manifest 'not.a.hash.foo': Not found: "In any BOSH release"`,
-// 		// `XXX`, // Trigger a fail which shows the contents of `actual`. Also template for new assertions.
-// 	}
-// 	for _, expected := range allExpected {
-// 		assert.Contains(actual, expected)
-// 	}
-// 	assert.Len(errs, len(allExpected))
-// }
+	actual := errs.Errors()
+	allExpected := []string{
+		`role-manifest 'not.a.hash.foo': Not found: "In any BOSH release"`,
+		// `XXX`, // Trigger a fail which shows the contents of `actual`. Also template for new assertions.
+	}
+	for _, expected := range allExpected {
+		assert.Contains(actual, expected)
+	}
+	assert.Len(errs, len(allExpected))
+}

--- a/kube/pod_test.go
+++ b/kube/pod_test.go
@@ -164,20 +164,28 @@ func TestPodGetEnvVars(t *testing.T) {
 	}
 
 	for _, sample := range samples {
-		defaults := map[string]string{"SOME_VAR": sample.input}
+		defaults := map[string]string{
+			"SOME_VAR": sample.input,
+			"ALL_VAR":  "placeholder",
+		}
 
 		vars, err := getEnvVars(role, defaults)
 		assert.NoError(err)
 		assert.NotEmpty(vars)
 
-		found := false
+		founda := false
+		foundb := false
 		for _, result := range vars {
 			if result.Name == "SOME_VAR" {
-				found = true
+				founda = true
 				assert.Equal(sample.expected, result.Value)
 			}
+			if result.Name == "ALL_VAR" {
+				foundb = true
+			}
 		}
-		assert.True(found, "failed to find expected variable")
+		assert.True(founda, "failed to find expected variable SOME_VAR")
+		assert.True(foundb, "failed to find expected variable ALL_VAR")
 	}
 }
 

--- a/model/roles_test.go
+++ b/model/roles_test.go
@@ -326,79 +326,115 @@ func TestGetRoleManifestDevPackageVersion(t *testing.T) {
 	assert.NotEqual(firstHash, differentExtraHash, "role manifest hash should be dependent on extra string")
 }
 
-// func TestLoadRoleManifestVariablesSortedError(t *testing.T) {
-// 	assert := assert.New(t)
+func TestLoadRoleManifestVariablesSortedError(t *testing.T) {
+	assert := assert.New(t)
 
-// 	workDir, err := os.Getwd()
-// 	assert.NoError(err)
+	workDir, err := os.Getwd()
+	assert.NoError(err)
 
-// 	torReleasePath := filepath.Join(workDir, "../test-assets/tor-boshrelease")
-// 	torReleasePathBoshCache := filepath.Join(torReleasePath, "bosh-cache")
-// 	release, err := NewDevRelease(torReleasePath, "", "", torReleasePathBoshCache)
-// 	assert.NoError(err)
+	torReleasePath := filepath.Join(workDir, "../test-assets/tor-boshrelease")
+	torReleasePathBoshCache := filepath.Join(torReleasePath, "bosh-cache")
+	release, err := NewDevRelease(torReleasePath, "", "", torReleasePathBoshCache)
+	assert.NoError(err)
 
-// 	roleManifestPath := filepath.Join(workDir, "../test-assets/role-manifests/variables-badly-sorted.yml")
-// 	rolesManifest, err := LoadRoleManifest(roleManifestPath, []*Release{release})
+	roleManifestPath := filepath.Join(workDir, "../test-assets/role-manifests/variables-badly-sorted.yml")
+	rolesManifest, err := LoadRoleManifest(roleManifestPath, []*Release{release})
 
-// 	assert.Contains(err.Error(), `configuration.variables: Invalid value: "FOO": Does not sort before 'BAR'`)
-// 	assert.Contains(err.Error(), `configuration.variables: Invalid value: "PELERINUL": Does not sort before 'ALPHA'`)
-// 	// Note how this ignores other errors possibly present in the manifest and releases.
-// 	assert.Nil(rolesManifest)
-// }
+	assert.Contains(err.Error(), `configuration.variables: Invalid value: "FOO": Does not sort before 'BAR'`)
+	assert.Contains(err.Error(), `configuration.variables: Invalid value: "PELERINUL": Does not sort before 'ALPHA'`)
+	// Note how this ignores other errors possibly present in the manifest and releases.
+	assert.Nil(rolesManifest)
+}
 
-// func TestLoadRoleManifestVariablesNotUsed(t *testing.T) {
-// 	assert := assert.New(t)
+func TestLoadRoleManifestVariablesNotUsed(t *testing.T) {
+	assert := assert.New(t)
 
-// 	workDir, err := os.Getwd()
-// 	assert.NoError(err)
+	workDir, err := os.Getwd()
+	assert.NoError(err)
 
-// 	torReleasePath := filepath.Join(workDir, "../test-assets/tor-boshrelease")
-// 	torReleasePathBoshCache := filepath.Join(torReleasePath, "bosh-cache")
-// 	release, err := NewDevRelease(torReleasePath, "", "", torReleasePathBoshCache)
-// 	assert.NoError(err)
+	torReleasePath := filepath.Join(workDir, "../test-assets/tor-boshrelease")
+	torReleasePathBoshCache := filepath.Join(torReleasePath, "bosh-cache")
+	release, err := NewDevRelease(torReleasePath, "", "", torReleasePathBoshCache)
+	assert.NoError(err)
 
-// 	roleManifestPath := filepath.Join(workDir, "../test-assets/role-manifests/variables-without-usage.yml")
-// 	rolesManifest, err := LoadRoleManifest(roleManifestPath, []*Release{release})
-// 	assert.Equal(err.Error(),
-// 		`configuration.variables: Not found: "No templates using 'SOME_VAR'"`)
-// 	assert.Nil(rolesManifest)
-// }
+	roleManifestPath := filepath.Join(workDir, "../test-assets/role-manifests/variables-without-usage.yml")
+	rolesManifest, err := LoadRoleManifest(roleManifestPath, []*Release{release})
+	assert.Equal(err.Error(),
+		`configuration.variables: Not found: "No templates using 'SOME_VAR'"`)
+	assert.Nil(rolesManifest)
+}
 
-// func TestLoadRoleManifestVariablesNotDeclared(t *testing.T) {
-// 	assert := assert.New(t)
+func TestLoadRoleManifestVariablesNotDeclared(t *testing.T) {
+	assert := assert.New(t)
 
-// 	workDir, err := os.Getwd()
-// 	assert.NoError(err)
+	workDir, err := os.Getwd()
+	assert.NoError(err)
 
-// 	torReleasePath := filepath.Join(workDir, "../test-assets/tor-boshrelease")
-// 	torReleasePathBoshCache := filepath.Join(torReleasePath, "bosh-cache")
-// 	release, err := NewDevRelease(torReleasePath, "", "", torReleasePathBoshCache)
-// 	assert.NoError(err)
+	torReleasePath := filepath.Join(workDir, "../test-assets/tor-boshrelease")
+	torReleasePathBoshCache := filepath.Join(torReleasePath, "bosh-cache")
+	release, err := NewDevRelease(torReleasePath, "", "", torReleasePathBoshCache)
+	assert.NoError(err)
 
-// 	roleManifestPath := filepath.Join(workDir, "../test-assets/role-manifests/variables-without-decl.yml")
-// 	rolesManifest, err := LoadRoleManifest(roleManifestPath, []*Release{release})
-// 	assert.Equal(err.Error(),
-// 		`configuration.variables: Not found: "No declaration of 'HOME'"`)
-// 	assert.Nil(rolesManifest)
-// }
+	roleManifestPath := filepath.Join(workDir, "../test-assets/role-manifests/variables-without-decl.yml")
+	rolesManifest, err := LoadRoleManifest(roleManifestPath, []*Release{release})
+	assert.Equal(err.Error(),
+		`configuration.variables: Not found: "No declaration of 'HOME'"`)
+	assert.Nil(rolesManifest)
+}
 
-// func TestLoadRoleManifestNonTemplates(t *testing.T) {
-// 	assert := assert.New(t)
+func TestLoadRoleManifestNonTemplates(t *testing.T) {
+	assert := assert.New(t)
 
-// 	workDir, err := os.Getwd()
-// 	assert.NoError(err)
+	workDir, err := os.Getwd()
+	assert.NoError(err)
 
-// 	torReleasePath := filepath.Join(workDir, "../test-assets/tor-boshrelease")
-// 	torReleasePathBoshCache := filepath.Join(torReleasePath, "bosh-cache")
-// 	release, err := NewDevRelease(torReleasePath, "", "", torReleasePathBoshCache)
-// 	assert.NoError(err)
+	torReleasePath := filepath.Join(workDir, "../test-assets/tor-boshrelease")
+	torReleasePathBoshCache := filepath.Join(torReleasePath, "bosh-cache")
+	release, err := NewDevRelease(torReleasePath, "", "", torReleasePathBoshCache)
+	assert.NoError(err)
 
-// 	roleManifestPath := filepath.Join(workDir, "../test-assets/role-manifests/templates-non.yml")
-// 	rolesManifest, err := LoadRoleManifest(roleManifestPath, []*Release{release})
-// 	assert.Equal(err.Error(),
-// 		`configuration.templates: Invalid value: "": Using 'properties.tor.hostname' as a constant`)
-// 	assert.Nil(rolesManifest)
-// }
+	roleManifestPath := filepath.Join(workDir, "../test-assets/role-manifests/templates-non.yml")
+	rolesManifest, err := LoadRoleManifest(roleManifestPath, []*Release{release})
+	assert.Equal(err.Error(),
+		`configuration.templates: Invalid value: "": Using 'properties.tor.hostname' as a constant`)
+	assert.Nil(rolesManifest)
+}
+
+func TestLoadRoleManifestBadCVType(t *testing.T) {
+	assert := assert.New(t)
+
+	workDir, err := os.Getwd()
+	assert.NoError(err)
+
+	torReleasePath := filepath.Join(workDir, "../test-assets/tor-boshrelease")
+	torReleasePathBoshCache := filepath.Join(torReleasePath, "bosh-cache")
+	release, err := NewDevRelease(torReleasePath, "", "", torReleasePathBoshCache)
+	assert.NoError(err)
+
+	roleManifestPath := filepath.Join(workDir, "../test-assets/role-manifests/bad-cv-type.yml")
+	rolesManifest, err := LoadRoleManifest(roleManifestPath, []*Release{release})
+	assert.Equal(err.Error(),
+		`configuration.variables[BAR].type: Invalid value: "bogus": Expected one of user, or environment`)
+	assert.Nil(rolesManifest)
+}
+
+func TestLoadRoleManifestBadCVTypeConflictInternal(t *testing.T) {
+	assert := assert.New(t)
+
+	workDir, err := os.Getwd()
+	assert.NoError(err)
+
+	torReleasePath := filepath.Join(workDir, "../test-assets/tor-boshrelease")
+	torReleasePathBoshCache := filepath.Join(torReleasePath, "bosh-cache")
+	release, err := NewDevRelease(torReleasePath, "", "", torReleasePathBoshCache)
+	assert.NoError(err)
+
+	roleManifestPath := filepath.Join(workDir, "../test-assets/role-manifests/bad-cv-type-internal.yml")
+	rolesManifest, err := LoadRoleManifest(roleManifestPath, []*Release{release})
+	assert.Equal(err.Error(),
+		`configuration.variables[BAR].type: Invalid value: "environment": type conflicts with flag "internal"`)
+	assert.Nil(rolesManifest)
+}
 
 func TestLoadRoleManifestRunEnvDocker(t *testing.T) {
 	assert := assert.New(t)

--- a/scripts/dockerfiles/run.sh
+++ b/scripts/dockerfiles/run.sh
@@ -20,6 +20,8 @@ if [ -d /var/vcap/sys/run ]; then
     find /var/vcap/sys/run -name "*.pid" -delete
 fi
 
+# Note, any changes to this list of variables have to be replicated in
+# --> model/mustache.go, func builtins
 export IP_ADDRESS=$(/bin/hostname -i | awk '{print $1}')
 export DNS_RECORD_NAME=$(/bin/hostname)
 

--- a/test-assets/role-manifests/bad-cv-type-internal.yml
+++ b/test-assets/role-manifests/bad-cv-type-internal.yml
@@ -25,9 +25,12 @@ roles:
 configuration:
   variables:
   - name: BAR
+    type: environment
+    internal: true
+  - name: FOO
   - name: HOME
   - name: PELERINUL
   templates:
-    properties.tor.hostname: ''
-    properties.tor.private_key: '((#BAR))((HOME))((/BAR))((IP_ADDRESS))((DNS_RECORD_NAME))'
+    properties.tor.hostname: '((FOO))'
+    properties.tor.private_key.thing: '((#BAR))((HOME))((/BAR))'
     properties.tor.hashed_control_password: '((={{ }}=)){{PELERINUL}}'

--- a/test-assets/role-manifests/bad-cv-type.yml
+++ b/test-assets/role-manifests/bad-cv-type.yml
@@ -25,9 +25,11 @@ roles:
 configuration:
   variables:
   - name: BAR
+    type: bogus
+  - name: FOO
   - name: HOME
   - name: PELERINUL
   templates:
-    properties.tor.hostname: ''
-    properties.tor.private_key: '((#BAR))((HOME))((/BAR))((IP_ADDRESS))((DNS_RECORD_NAME))'
+    properties.tor.hostname: '((FOO))'
+    properties.tor.private_key.thing: '((#BAR))((HOME))((/BAR))'
     properties.tor.hashed_control_password: '((={{ }}=)){{PELERINUL}}'

--- a/test-assets/role-manifests/templates-non.yml
+++ b/test-assets/role-manifests/templates-non.yml
@@ -29,5 +29,5 @@ configuration:
   - name: PELERINUL
   templates:
     properties.tor.hostname: ''
-    properties.tor.private_key: '((#BAR))((HOME))((/BAR))((IP_ADDRESS))((DNS_RECORD_NAME))'
+    properties.tor.private_key: '((#BAR))((HOME))((/BAR))'
     properties.tor.hashed_control_password: '((={{ }}=)){{PELERINUL}}'

--- a/test-assets/role-manifests/tor-validation-ok.yml
+++ b/test-assets/role-manifests/tor-validation-ok.yml
@@ -27,6 +27,8 @@ configuration:
   - name: BAR
   - name: FOO
   - name: HOME
+  - name: KUPRIES
+    internal: true
   - name: PELERINUL
   templates:
     properties.tor.hostname: '((FOO))'

--- a/test-assets/role-manifests/volumes.yml
+++ b/test-assets/role-manifests/volumes.yml
@@ -20,4 +20,6 @@ configuration:
   templates:
     fox: ((SOME_VAR))
   variables:
+  - name: ALL_VAR
+    internal: true
   - name: SOME_VAR


### PR DESCRIPTION
And register fissile's internal variables for use in templates.

Ticket: https://trello.com/c/e3sNBThS/63-fissile-it-s-broken
Rebased to include PR 220.
Rebased to include PR 225.

Latest changes include work for `type: user|environment`, `internal: true|false`.
Needs another review/look now.

Rebased to resolve conflicts, clean up of history. Now ready, IMVHO.