### PR TITLE
model: When looking for env vars, pick up descendent properties too

### DIFF
--- a/model/mustache.go
+++ b/model/mustache.go
@@ -3,6 +3,7 @@ package model
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/hpcloud/fissile/mustache"
 )
@@ -31,7 +32,14 @@ func (r *Role) GetVariablesForRole() (ConfigurationVariableSlice, error) {
 		for _, property := range job.Properties {
 			propertyName := fmt.Sprintf("properties.%s", property.Name)
 
-			if template, ok := r.Configuration.Templates[propertyName]; ok {
+			for templatePropName, template := range r.Configuration.Templates {
+				switch true {
+				case templatePropName == propertyName:
+				case strings.HasPrefix(templatePropName, propertyName+"."):
+				default:
+					// Not a matching property
+					continue
+				}
 				varsInTemplate, err := parseTemplate(template)
 				if err != nil {
 					return nil, err

--- a/model/mustache_test.go
+++ b/model/mustache_test.go
@@ -3,6 +3,7 @@ package model
 import (
 	"os"
 	"path/filepath"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -53,8 +54,11 @@ func TestRoleVariables(t *testing.T) {
 	assert.NotNil(vars)
 
 	expected := []string{"HOME", "FOO", "BAR", "PELERINUL"}
-	assert.Len(vars, len(expected))
-	for i, variable := range vars {
-		assert.Contains(expected, variable.Name, "variable %d not expected", i)
+	sort.Strings(expected)
+	var actual []string
+	for _, variable := range vars {
+		actual = append(actual, variable.Name)
 	}
+	sort.Strings(actual)
+	assert.Equal(expected, actual)
 }

--- a/test-assets/role-manifests/tor-good.yml
+++ b/test-assets/role-manifests/tor-good.yml
@@ -30,5 +30,5 @@ configuration:
   - name: PELERINUL
   templates:
     properties.tor.hostname: '((FOO))'
-    properties.tor.private_key: '((#BAR))((HOME))((/BAR))'
+    properties.tor.private_key.thing: '((#BAR))((HOME))((/BAR))'
     properties.tor.hashed_control_password: '((={{ }}=)){{PELERINUL}}'


### PR DESCRIPTION
When a spec calls for a property like `properties.foo`, also pick up environment variables listed in children like `properties.foo.bar`. This is required because when we eventually serialize `properties.foo` (via configgin) it will need `properties.foo.bar` in there somewhere.