### PR TITLE
Fix compatibility with golang 1.8

### DIFF
--- a/docker/docker_test.go
+++ b/docker/docker_test.go
@@ -14,7 +14,6 @@ import (
 
 	dockerclient "github.com/fsouza/go-dockerclient"
 	"github.com/golang/mock/gomock"
-	_ "github.com/golang/mock/mockgen" // Force godep to pick it up
 	"github.com/hpcloud/fissile/util"
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"

--- a/test-assets/extra-imports.go
+++ b/test-assets/extra-imports.go
@@ -1,0 +1,14 @@
+// +build plan9
+
+// Package testassets exists to pull in extra dependencies that are used for tests
+// so they get vendored correctly; this file is never built.
+package testassets
+
+import (
+	"github.com/golang/mock/mockgen"
+)
+
+func unused() error {
+	_, err := mockgen.ParseFile("source")
+	return err
+}


### PR DESCRIPTION
Golang 1.8 no longer allows importing programs for side effects; instead we move it to a package we never build (unless on plan9, which we don't actually support anyway).

Fixes #221