### PR TITLE
compile: follow /fissile-out symlink on final chown

### DIFF
--- a/scripts/compilation/ubuntu-compile.sh
+++ b/scripts/compilation/ubuntu-compile.sh
@@ -48,4 +48,5 @@ fi
 cd "${BOSH_COMPILE_TARGET}"
 bash ./packaging
 
-chown -R "${HOST_USERID}:${HOST_USERGID}" "${BOSH_INSTALL_TARGET}" 2>/dev/null || echo "Warning - could not change ownership of compiled artifacts" 1>&2
+chown -R "${HOST_USERID}:${HOST_USERGID}" "$(readlink --canonicalize "${BOSH_INSTALL_TARGET}")" 2>/dev/null \
+  || echo "Warning - could not change ownership of compiled artifacts" 1>&2


### PR DESCRIPTION
When building under docker, `${BOSH_INSTALL_TARGET}` is a symlink to `/fissile-out`.  When running chown on it, we need to follow that first symlink to make sure we actually change ownership of the files (and not the symlink itself).